### PR TITLE
fix(transport-matrix): drain trailing agent_message_chunks after prompt resolves

### DIFF
--- a/.changeset/drain-trailing-chunks.md
+++ b/.changeset/drain-trailing-chunks.md
@@ -1,0 +1,11 @@
+---
+"@zooid/transport-matrix": patch
+---
+
+Drain trailing `agent_message_chunk`s after a turn resolves. ACP does not
+guarantee that all `session/update` notifications precede the `session/prompt`
+response for a normal turn (only the cancellation path mandates it), and some
+agents (e.g. opencode) flush a final chunk just after the stop reason. The
+transport now waits for the per-session buffer to stay quiet for a short grace
+window (debounced, capped) before sending, instead of flushing the moment
+`prompt()` resolves — which previously truncated or dropped replies.

--- a/packages/transport-matrix/src/transport.test.ts
+++ b/packages/transport-matrix/src/transport.test.ts
@@ -56,7 +56,7 @@ const baseAgents = [
   },
 ]
 
-function makeTransport() {
+function makeTransport(drain?: { drainQuietMs?: number; drainMaxMs?: number }) {
   const { reg, finishPrompt } = fakeRegistry()
   const approvals = fakeApprovals()
   const client = fakeClient()
@@ -66,6 +66,10 @@ function makeTransport() {
     client: client as never,
     bindings: baseAgents,
     hsToken: 'hs-secret',
+    // Disable post-turn drain by default so settleTurn (microtasks) suffices.
+    // Tests covering trailing-chunk behavior pass an explicit window.
+    drainQuietMs: drain?.drainQuietMs ?? 0,
+    drainMaxMs: drain?.drainMaxMs,
   })
   return { transport, agents: reg, approvals, client, finishPrompt }
 }
@@ -141,6 +145,58 @@ describe('matrix transport /transactions', () => {
         asUserId: '@architect:example.com',
         threadRoot: '$root',
         content: expect.objectContaining({ msgtype: 'm.text', body: 'hello back' }),
+      }),
+    )
+  })
+
+  it('drains trailing agent_message_chunks that arrive after prompt() resolves', async () => {
+    // ACP doesn't guarantee all session/update chunks precede the prompt
+    // response for a normal turn; opencode flushes a trailing chunk just after
+    // the stopReason. The post-turn drain must wait for it instead of sending
+    // the truncated buffer.
+    const { transport, agents, client } = makeTransport({ drainQuietMs: 20, drainMaxMs: 500 })
+    const events = [
+      {
+        type: 'm.room.message',
+        event_id: '$root',
+        room_id: '!r:example.com',
+        sender: '@alice:example.com',
+        content: {
+          msgtype: 'm.text',
+          body: 'hi',
+          'm.mentions': { user_ids: ['@architect:example.com'] },
+        },
+      },
+    ]
+    agents.prompt.mockImplementation(async (_name: string, p: { threadId: string }) => {
+      const sessionId = 'sess-' + p.threadId
+      // First chunk arrives during the turn…
+      agents.onEvent('architect', {
+        type: 'agent_message_chunk',
+        sessionId,
+        content: { type: 'text', text: 'Hi.' },
+      })
+      // …a second chunk lands shortly AFTER the prompt response resolves.
+      setTimeout(() => {
+        agents.onEvent('architect', {
+          type: 'agent_message_chunk',
+          sessionId,
+          content: { type: 'text', text: ' How can I help?' },
+        })
+      }, 5)
+      return { stopReason: 'end_turn' as const }
+    })
+
+    const res = await postTxn(transport.app, { events })
+    expect(res.status).toBe(200)
+    // Wait past the drain window for the turn to finalize.
+    await new Promise((r) => setTimeout(r, 150))
+
+    // Exactly one message, containing BOTH the early and the late chunk.
+    expect(client.sendMessage).toHaveBeenCalledTimes(1)
+    expect(client.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({ body: 'Hi. How can I help?' }),
       }),
     )
   })

--- a/packages/transport-matrix/src/transport.ts
+++ b/packages/transport-matrix/src/transport.ts
@@ -18,6 +18,12 @@ export interface CreateMatrixTransportOptions {
   hsToken: string
   /** Admin Matrix user ID. When set, BotPool.bootstrap invites this user into rooms it creates. */
   adminUserId?: string
+  /** Post-turn drain: keep collecting trailing `agent_message_chunk`s until the
+   *  buffer is quiet for this long before flushing. Defaults to `DRAIN_QUIET_MS`.
+   *  Set to 0 to disable the drain (e.g. in tests). */
+  drainQuietMs?: number
+  /** Hard cap on the post-turn drain. Defaults to `DRAIN_MAX_MS`. */
+  drainMaxMs?: number
 }
 
 interface SessionContext {
@@ -43,6 +49,19 @@ interface MatrixEvent {
 const STARTUP_GRACE_MS = 5_000
 const SEEN_EVENT_CAP = 5_000
 
+// ACP only guarantees that an agent flushes pending `session/update`
+// notifications before the `session/prompt` response in the *cancellation*
+// path; for a normal turn the ordering is unspecified. Some agents (e.g.
+// opencode) emit trailing `agent_message_chunk`s a few ms after the stopReason
+// response, so finalizing the moment `prompt()` resolves truncates the reply.
+// After the turn resolves we wait for the buffer to stay unchanged for
+// DRAIN_QUIET_MS (debounce — re-arms on each late chunk) before flushing,
+// capped at DRAIN_MAX_MS so a misbehaving stream can't hang the turn.
+const DRAIN_QUIET_MS = 300
+const DRAIN_MAX_MS = 3_000
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
 function inboundThreadRoot(evt: MatrixEvent): string | undefined {
   const r = evt.content?.['m.relates_to']
   return r?.rel_type === 'm.thread' && r.event_id ? r.event_id : undefined
@@ -50,6 +69,8 @@ function inboundThreadRoot(evt: MatrixEvent): string | undefined {
 
 export function createMatrixTransport(opts: CreateMatrixTransportOptions) {
   const { agents, approvals, client, bindings, hsToken, adminUserId } = opts
+  const drainQuietMs = opts.drainQuietMs ?? DRAIN_QUIET_MS
+  const drainMaxMs = opts.drainMaxMs ?? DRAIN_MAX_MS
   const pool = new BotPool(client, bindings)
   const sessions = new Map<string, SessionContext>()
   const buffers = new Map<string, string>()
@@ -418,6 +439,17 @@ export function createMatrixTransport(opts: CreateMatrixTransportOptions) {
         channelId: evt.room_id,
         content: [{ type: 'text', text: promptText }],
       })
+      // Drain: the prompt promise resolves on the stopReason response, but
+      // trailing chunks may still arrive (see DRAIN_* above). Wait until the
+      // buffer is quiet for DRAIN_QUIET_MS, re-arming on each new chunk.
+      const drainStart = Date.now()
+      let drained = buffers.get(sessionId) ?? ''
+      while (drainQuietMs > 0 && Date.now() - drainStart < drainMaxMs) {
+        await delay(drainQuietMs)
+        const next = buffers.get(sessionId) ?? ''
+        if (next === drained) break
+        drained = next
+      }
       const text = buffers.get(sessionId) ?? ''
       if (text.length > 0) {
         const html = toMatrixHtml(text)


### PR DESCRIPTION
## Summary
- Fixes truncated/empty agent replies (e.g. `Hi. What` instead of the full message, or `turn finished with empty buffer`) observed when running the **opencode** preset on a self-hosted box.
- Root cause: ACP only guarantees pending `session/update` notifications are flushed before the `session/prompt` response in the **cancellation** path. For a normal turn the ordering is unspecified, and opencode emits a final `agent_message_chunk` just *after* the `stopReason` response. The transport read+flushed the per-session buffer the instant `prompt()` resolved, dropping those trailing chunks.
- Fix: after the turn resolves, wait for the buffer to stay unchanged for a short grace window (debounced — re-arms on each late chunk, capped by `drainMaxMs`) before sending. Timing is injectable via `drainQuietMs`/`drainMaxMs` (defaults 300ms / 3s).

## Why it's environment-sensitive
The gap between opencode writing the `stopReason` response and its trailing chunk is a local stdout write-ordering race, influenced by model-stream cadence and container stdout buffering — so it reproduces intermittently (more often on EC2/amd64, but also locally for multi-chunk replies).

## Test plan
- [x] New unit test: a chunk emitted *after* `prompt()` resolves is still included in the flushed message (`drains trailing agent_message_chunks that arrive after prompt() resolves`).
- [x] Existing transport-matrix unit suite passes (drain disabled in the harness via `drainQuietMs: 0`).
- [x] Verified end-to-end on a self-hosted EC2 box: `hi` → full `Hi. How can I help with your workforce?` (previously truncated to `Hi. What`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)