### PR TITLE
Multi-workstation pull transport: identity + pull /sync + daemon wiring (ZOD063/064/066)

### DIFF
--- a/packages/cli/src/bootstrap/configs.ts
+++ b/packages/cli/src/bootstrap/configs.ts
@@ -1,5 +1,7 @@
+import { join } from 'node:path'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { renderRegistration } from '@zooid/transport-matrix'
+import { deriveRegistrationUrl } from './registration-url.js'
 import type { Paths } from './paths.js'
 
 export interface TuwunelTomlOpts {
@@ -35,6 +37,12 @@ export interface BootstrapConfigsOpts {
   hsToken: string
   senderLocalpart: string
   userNamespace: string
+  /** Workstation slug. When set: registration id = slug, exclusive namespace, url derived from port/advertise_url. */
+  slug?: string
+  /** AS HTTP listener port. Used to derive the registration url when slug is set. */
+  port?: number
+  /** Explicit registration url override. Mutually exclusive with port. */
+  advertiseUrl?: string
 }
 
 export function writeBootstrapConfigs(opts: BootstrapConfigsOpts): void {
@@ -45,9 +53,16 @@ export function writeBootstrapConfigs(opts: BootstrapConfigsOpts): void {
 
   writeFileSync(paths.tuwunelTomlPath, renderTuwunelToml({ serverName }))
 
+  const id = opts.slug ?? 'zooid'
+  const url = opts.slug
+    ? deriveRegistrationUrl({ port: opts.port ?? 9099, advertise_url: opts.advertiseUrl })
+    : `http://host.docker.internal:9099`
+  const exclusive = !!opts.slug
+  const registrationPath = join(paths.registrationsDir, `${id}.yaml`)
+
   const yaml = renderRegistration({
-    id: 'zooid',
-    url: `http://host.docker.internal:9099`,
+    id,
+    url,
     homeserver: `http://localhost:${TUWUNEL_INTERNAL_PORT}`,
     asToken,
     hsToken,
@@ -56,9 +71,7 @@ export function writeBootstrapConfigs(opts: BootstrapConfigsOpts): void {
     // BotPool.bootstrap creates `#alias:<server>` rooms when missing — the
     // AS needs an aliases namespace to legally claim them.
     aliasNamespace: `#.*:${serverName}`,
-    // zooid dev shares @.*:<server_name> between bots and the predefined
-    // admin human, so the AS cannot claim the namespace exclusively.
-    exclusive: false,
+    exclusive,
   })
-  writeFileSync(paths.appserviceYamlPath, yaml)
+  writeFileSync(registrationPath, yaml)
 }

--- a/packages/cli/src/bootstrap/configs.ts
+++ b/packages/cli/src/bootstrap/configs.ts
@@ -37,9 +37,9 @@ export interface BootstrapConfigsOpts {
   hsToken: string
   senderLocalpart: string
   userNamespace: string
-  /** Workstation slug. When set: registration id = slug, exclusive namespace, url derived from port/advertise_url. */
-  slug?: string
-  /** AS HTTP listener port. Used to derive the registration url when slug is set. */
+  /** Workstation id. When set: registration id = workstation, exclusive namespace, url derived from port/advertise_url. */
+  workstation?: string
+  /** AS HTTP listener port. Used to derive the registration url when workstation is set. */
   port?: number
   /** Explicit registration url override. Mutually exclusive with port. */
   advertiseUrl?: string
@@ -53,11 +53,11 @@ export function writeBootstrapConfigs(opts: BootstrapConfigsOpts): void {
 
   writeFileSync(paths.tuwunelTomlPath, renderTuwunelToml({ serverName }))
 
-  const id = opts.slug ?? 'zooid'
-  const url = opts.slug
+  const id = opts.workstation ?? 'zooid'
+  const url = opts.workstation
     ? deriveRegistrationUrl({ port: opts.port ?? 9099, advertise_url: opts.advertiseUrl })
     : `http://host.docker.internal:9099`
-  const exclusive = !!opts.slug
+  const exclusive = !!opts.workstation
   const registrationPath = join(paths.registrationsDir, `${id}.yaml`)
 
   const yaml = renderRegistration({

--- a/packages/cli/src/bootstrap/derive.ts
+++ b/packages/cli/src/bootstrap/derive.ts
@@ -6,7 +6,8 @@ export interface HomeserverShape {
   serverName: string
 }
 
-const NAMESPACE_RE = /^@\.\*:([A-Za-z0-9.-]+)$/
+// Matches @.*:server (flat) or @slug\..*:server (slug-scoped exclusive namespace)
+const NAMESPACE_RE = /^@(?:\.\*|[a-z0-9-]+\\\.\.\*):([A-Za-z0-9.-]+)$/
 
 export function deriveHomeserverShape(
   matrix: MatrixTransportConfig,
@@ -23,7 +24,7 @@ export function deriveHomeserverShape(
   const m = NAMESPACE_RE.exec(matrix.user_namespace)
   if (!m) {
     throw new Error(
-      `user_namespace ${matrix.user_namespace!}: expected the simple form '@.*:<server_name>'`,
+      `user_namespace ${matrix.user_namespace!}: expected '@.*:<server_name>' or '@<slug>\\\..*:<server_name>'`,
     )
   }
   const serverName = m[1]!

--- a/packages/cli/src/bootstrap/derive.ts
+++ b/packages/cli/src/bootstrap/derive.ts
@@ -6,7 +6,7 @@ export interface HomeserverShape {
   serverName: string
 }
 
-// Matches @.*:server (flat) or @slug\..*:server (slug-scoped exclusive namespace)
+// Matches @.*:server (flat) or @<workstation>\..*:server (workstation-scoped exclusive namespace)
 const NAMESPACE_RE = /^@(?:\.\*|[a-z0-9-]+\\\.\.\*):([A-Za-z0-9.-]+)$/
 
 export function deriveHomeserverShape(
@@ -24,7 +24,7 @@ export function deriveHomeserverShape(
   const m = NAMESPACE_RE.exec(matrix.user_namespace)
   if (!m) {
     throw new Error(
-      `user_namespace ${matrix.user_namespace!}: expected '@.*:<server_name>' or '@<slug>\\\..*:<server_name>'`,
+      `user_namespace ${matrix.user_namespace!}: expected '@.*:<server_name>' or '@<workstation>\\\..*:<server_name>'`,
     )
   }
   const serverName = m[1]!

--- a/packages/cli/src/bootstrap/identity-bootstrap.integration.test.ts
+++ b/packages/cli/src/bootstrap/identity-bootstrap.integration.test.ts
@@ -9,7 +9,7 @@ import { resolvePaths } from './paths.js'
 
 const YAML = `
 runtime: podman
-slug: laptop
+workstation: laptop
 transports:
   matrix:
     homeserver: http://localhost:8448
@@ -20,11 +20,11 @@ agents:
   docs: { acp: { preset: opencode }, matrix: { rooms: ['#docs'] } }
 `
 
-describe('bootstrap emits a slug-scoped registration', () => {
+describe('bootstrap emits a workstation-scoped registration', () => {
   let dir: string
   afterEach(() => dir && rmSync(dir, { recursive: true, force: true }))
 
-  it('config → registration round-trip is slug-consistent', () => {
+  it('config → registration round-trip is workstation-consistent', () => {
     dir = mkdtempSync(join(tmpdir(), 'zod063-'))
     const dataDir = join(dir, 'data', 'matrix')
     const paths = resolvePaths(dataDir)
@@ -38,7 +38,7 @@ describe('bootstrap emits a slug-scoped registration', () => {
       hsToken: 'hs-x',
       senderLocalpart: m.sender_localpart,
       userNamespace: m.user_namespace,
-      slug: m.slug,
+      workstation: m.workstation,
       port: m.port,
     })
 

--- a/packages/cli/src/bootstrap/identity-bootstrap.integration.test.ts
+++ b/packages/cli/src/bootstrap/identity-bootstrap.integration.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { parse } from 'yaml'
+import { loadZooidConfig, findMatrixTransport } from '@zooid/core'
+import { writeBootstrapConfigs } from './configs.js'
+import { resolvePaths } from './paths.js'
+
+const YAML = `
+runtime: podman
+slug: laptop
+transports:
+  matrix:
+    homeserver: http://localhost:8448
+    as_token: as-x
+    hs_token: hs-x
+    port: 9099
+agents:
+  docs: { acp: { preset: opencode }, matrix: { rooms: ['#docs'] } }
+`
+
+describe('bootstrap emits a slug-scoped registration', () => {
+  let dir: string
+  afterEach(() => dir && rmSync(dir, { recursive: true, force: true }))
+
+  it('config → registration round-trip is slug-consistent', () => {
+    dir = mkdtempSync(join(tmpdir(), 'zod063-'))
+    const dataDir = join(dir, 'data', 'matrix')
+    const paths = resolvePaths(dataDir)
+    const cfg = loadZooidConfig(YAML)
+    const m = findMatrixTransport(cfg)!.transport
+
+    writeBootstrapConfigs({
+      paths,
+      serverName: new URL(m.homeserver).hostname,
+      asToken: 'as-x',
+      hsToken: 'hs-x',
+      senderLocalpart: m.sender_localpart,
+      userNamespace: m.user_namespace,
+      slug: m.slug,
+      port: m.port,
+    })
+
+    const regPath = join(dataDir, 'config', 'registrations', 'laptop.yaml')
+    const reg = parse(readFileSync(regPath, 'utf8'))
+    expect(reg.id).toBe('laptop')
+    expect(reg.sender_localpart).toBe('laptop')
+    expect(reg.namespaces.users[0]).toEqual({ exclusive: true, regex: '@laptop\\..*:localhost' })
+    // co-located: url advertises the daemon's bind port back to the homeserver
+    expect(reg.url).toBe('http://host.docker.internal:9099')
+  })
+})

--- a/packages/cli/src/bootstrap/registration-url.test.ts
+++ b/packages/cli/src/bootstrap/registration-url.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { deriveRegistrationUrl } from './registration-url.js'
+
+describe('deriveRegistrationUrl', () => {
+  it('port → co-located host.docker.internal shorthand', () => {
+    expect(deriveRegistrationUrl({ port: 9099 })).toBe('http://host.docker.internal:9099')
+  })
+  it('advertise_url → verbatim', () => {
+    expect(deriveRegistrationUrl({ advertise_url: 'http://10.0.1.5:9099' })).toBe('http://10.0.1.5:9099')
+  })
+  it('throws if both are present (caller should have rejected earlier, defense-in-depth)', () => {
+    expect(() => deriveRegistrationUrl({ port: 9099, advertise_url: 'http://x:1' })).toThrow()
+  })
+})

--- a/packages/cli/src/bootstrap/registration-url.ts
+++ b/packages/cli/src/bootstrap/registration-url.ts
@@ -1,0 +1,7 @@
+export function deriveRegistrationUrl(opts: { port?: number; advertise_url?: string }): string {
+  if (opts.port != null && opts.advertise_url != null)
+    throw new Error("registration url: 'port' and 'advertise_url' are mutually exclusive")
+  if (opts.advertise_url != null) return opts.advertise_url
+  if (opts.port != null) return `http://host.docker.internal:${opts.port}`
+  throw new Error('registration url: need port or advertise_url')
+}

--- a/packages/cli/src/daemon/pull-wiring.test.ts
+++ b/packages/cli/src/daemon/pull-wiring.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { shouldBindHttpListener } from './pull-wiring.js'
+
+describe('shouldBindHttpListener', () => {
+  it('binds in appservice (push) mode — homeserver pushes to the daemon', () => {
+    expect(shouldBindHttpListener('appservice')).toBe(true)
+  })
+  it('does NOT bind in client (pull) mode — daemon polls outbound /sync', () => {
+    expect(shouldBindHttpListener('client')).toBe(false)
+  })
+  it('defaults to binding when mode is undefined', () => {
+    expect(shouldBindHttpListener(undefined)).toBe(true)
+  })
+})

--- a/packages/cli/src/daemon/pull-wiring.ts
+++ b/packages/cli/src/daemon/pull-wiring.ts
@@ -1,0 +1,4 @@
+/** Push (`appservice`) binds an inbound listener; pull (`client`) does not. */
+export function shouldBindHttpListener(mode: 'appservice' | 'client' | undefined): boolean {
+  return mode !== 'client'
+}

--- a/packages/cli/src/daemon/start-daemon-pull.integration.test.ts
+++ b/packages/cli/src/daemon/start-daemon-pull.integration.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startDaemon } from './start-daemon.js'
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'zooid-pull-'))
+})
+afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+// Permissive stub: bootstrap CS calls all succeed with a benign body; the
+// /sync endpoint returns one page (carrying next_batch `s-1`) then idles. The
+// idle page is *paced* (~150ms) to mimic the long-poll — SyncLoop.run() has no
+// inter-tick delay, so an instant stub would busy-loop. This proves the daemon
+// selects + drives the pull loop; event→runTurn dispatch is covered in ZOD064.
+function pullFetchStub() {
+  let synced = false
+  return vi.fn(async (input: string | URL) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString())
+    if (url.pathname === '/_matrix/client/v3/sync') {
+      if (synced) {
+        await delay(150)
+        return new Response(JSON.stringify({ next_batch: 's-idle', rooms: { join: {} } }), {
+          status: 200,
+        })
+      }
+      synced = true
+      return new Response(JSON.stringify({ next_batch: 's-1', rooms: { join: {} } }), {
+        status: 200,
+      })
+    }
+    if (url.pathname.endsWith('/account/whoami')) {
+      return new Response(JSON.stringify({ user_id: '@laptop:zoon.eco' }), { status: 200 })
+    }
+    // createRoom / register / join / send / state — benign shapes.
+    if (url.pathname.endsWith('/createRoom')) {
+      return new Response(JSON.stringify({ room_id: '!stub:zoon.eco' }), { status: 200 })
+    }
+    return new Response('{}', { status: 200 })
+  }) as unknown as typeof globalThis.fetch
+}
+
+describe('startDaemon — matrix client (pull) mode', () => {
+  it('binds no HTTP listener, runs the sync loop, persists a cursor, stops cleanly', async () => {
+    const yamlPath = join(dir, 'zooid.yaml')
+    writeFileSync(
+      yamlPath,
+      [
+        'runtime: local',
+        'workstation: laptop',
+        'transports:',
+        '  matrix:',
+        '    homeserver: https://zoon.eco',
+        '    mode: client',
+        '    as_token: test-as-token',
+        '    hs_token: test-hs-token',
+        'agents:',
+        '  docs:',
+        '    workdir: .',
+        '    acp: { preset: claude }',
+        '    matrix:',
+        '      transport: matrix',
+        "      rooms: ['#general']",
+      ].join('\n'),
+    )
+
+    const agentsDir = join(dir, 'data', 'agents')
+    const handle = await startDaemon({
+      configPath: yamlPath,
+      installSignalHandlers: false,
+      agentsDir,
+      fetch: pullFetchStub(),
+    })
+
+    // (a) No inbound listener in pull mode.
+    expect(handle.port).toBe(0)
+    expect(handle.agentNames).toEqual(['docs'])
+
+    // (c) Cursor persisted for the agent after a sync page is consumed, beside
+    //     sessions.json under <agentsDir>/<agentName>/. run() ticks async.
+    const sincePath = join(agentsDir, 'docs', 'sync-since')
+    await vi.waitFor(() => expect(existsSync(sincePath)).toBe(true), {
+      timeout: 3000,
+      interval: 50,
+    })
+
+    // (b) Clean, idempotent shutdown stops the loop (no hanging long-poll).
+    await handle.stop()
+    await handle.stop()
+  })
+})

--- a/packages/cli/src/daemon/start-daemon.ts
+++ b/packages/cli/src/daemon/start-daemon.ts
@@ -24,6 +24,7 @@ import {
   startWorkforcePublisher,
   type AgentBinding,
   type PublisherHandle,
+  type SyncLoop,
 } from '@zooid/transport-matrix'
 import {
   SpawnRegistry,
@@ -32,6 +33,8 @@ import {
 } from '@zooid/context-mcp'
 import { buildAcpRegistry } from '../build-registry.js'
 import { prepullImages } from '../prepull-images.js'
+import { makeSyncCursorStore } from './sync-cursors.js'
+import { shouldBindHttpListener } from './pull-wiring.js'
 
 export interface StartDaemonOpts {
   configPath?: string
@@ -66,6 +69,11 @@ export interface StartDaemonOpts {
    * task instead of leaving the user staring at an unmoving spinner.
    */
   prepullLog?: (line: string) => void
+  /**
+   * Override the global fetch used by the daemon's MatrixClient. Test seam for
+   * driving pull mode against canned /sync responses without a homeserver.
+   */
+  fetch?: typeof globalThis.fetch
 }
 
 export interface DaemonHandle {
@@ -149,6 +157,7 @@ export async function startDaemon(opts: StartDaemonOpts = {}): Promise<DaemonHan
   )
 
   let server: ServerType | null = null
+  let syncLoops: SyncLoop[] | undefined
   let stopped = false
   let resolveStopped!: () => void
   const whenStopped = new Promise<void>((r) => {
@@ -159,9 +168,17 @@ export async function startDaemon(opts: StartDaemonOpts = {}): Promise<DaemonHan
   let port: number
 
   if (matrix) {
+    const mode = matrix.transport.mode ?? 'appservice'
+    // Pull (client) mode persists a per-agent `since` cursor for offline resume,
+    // so it needs a data dir. Push mode doesn't.
+    if (mode === 'client' && !opts.agentsDir) {
+      throw new Error('matrix client (pull) mode requires a data dir for since-cursor persistence')
+    }
+    const cursors = opts.agentsDir ? makeSyncCursorStore(opts.agentsDir) : undefined
     const client = new MatrixClient({
       homeserver: matrix.transport.homeserver,
       asToken: matrix.transport.as_token,
+      ...(opts.fetch ? { fetch: opts.fetch } : {}),
     })
     const mediaClient = new MediaClient({
       homeserver: matrix.transport.homeserver,
@@ -191,6 +208,9 @@ export async function startDaemon(opts: StartDaemonOpts = {}): Promise<DaemonHan
       matrix.transport.user_namespace.split(':').slice(1).join(':').replace(/\\?\)?$/, '') ||
       new URL(matrix.transport.homeserver).hostname
     const asUserId = `@${matrix.transport.sender_localpart}:${serverName}`
+    // Pull mode's loadSince/saveSince are keyed by MXID; the cursor store is
+    // keyed by agent name. Translate via the bindings we just built.
+    const nameByUserId = new Map(bindings.map((b) => [b.userId, b.name]))
     const transport = createMatrixTransport({
       agents: registry,
       approvals,
@@ -200,13 +220,27 @@ export async function startDaemon(opts: StartDaemonOpts = {}): Promise<DaemonHan
       adminUserId: opts.adminUserId,
       botUserId: asUserId,
       media: mediaClient,
+      mode,
+      loadSince: (uid) => {
+        const name = nameByUserId.get(uid)
+        return name && cursors ? cursors.loadSince(name) : null
+      },
+      saveSince: (uid, since) => {
+        const name = nameByUserId.get(uid)
+        if (name && cursors) cursors.saveSince(name, since)
+      },
     })
-    const requestedPort = matrix.transport.port ?? 9000
-    // Bind 0.0.0.0 explicitly — @hono/node-server defaults to IPv6-only on
-    // macOS, which Docker's NAT bridge can't reach when Tuwunel pushes AS
-    // events back to host.docker.internal:<port>.
-    server = serve({ fetch: transport.app.fetch, port: requestedPort, hostname: '0.0.0.0' })
-    port = await listenAsync(server)
+    if (shouldBindHttpListener(mode)) {
+      const requestedPort = matrix.transport.port ?? 9000
+      // Bind 0.0.0.0 explicitly — @hono/node-server defaults to IPv6-only on
+      // macOS, which Docker's NAT bridge can't reach when Tuwunel pushes AS
+      // events back to host.docker.internal:<port>.
+      server = serve({ fetch: transport.app.fetch, port: requestedPort, hostname: '0.0.0.0' })
+      port = await listenAsync(server)
+    } else {
+      // Pull (client) mode runs outbound /sync loops; no inbound listener.
+      port = 0
+    }
     const spaceLocalpart = matrix.transport.space ?? 'dev'
     const adminUserIds = opts.adminUserId ? [opts.adminUserId] : []
     let spaceRoomId: string | undefined
@@ -232,6 +266,14 @@ export async function startDaemon(opts: StartDaemonOpts = {}): Promise<DaemonHan
     // *after* the space exists so BotPool can attach each agent room as
     // m.space.child while joining it.
     await transport.bootstrap({ spaceRoomId, asUserId, adminUserIds })
+
+    // Pull mode: start the outbound /sync loops after bootstrap so the rooms
+    // each agent syncs already exist. Loops long-poll until stop().
+    syncLoops = transport.syncLoops
+    if (syncLoops?.length) {
+      for (const loop of syncLoops) void loop.run()
+      console.log(`[matrix] pull mode: ${syncLoops.length} sync loop(s) running`)
+    }
 
     if (spaceRoomId) {
       try {
@@ -272,6 +314,11 @@ export async function startDaemon(opts: StartDaemonOpts = {}): Promise<DaemonHan
   const stop = async (): Promise<void> => {
     if (stopped) return whenStopped
     stopped = true
+    try {
+      if (syncLoops) for (const loop of syncLoops) loop.stop()
+    } catch {
+      // swallow
+    }
     try {
       if (server) await closeAsync(server)
     } catch {

--- a/packages/cli/src/daemon/sync-cursors.test.ts
+++ b/packages/cli/src/daemon/sync-cursors.test.ts
@@ -1,0 +1,38 @@
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { makeSyncCursorStore } from './sync-cursors.js'
+
+let agentsDir: string
+beforeEach(() => {
+  agentsDir = mkdtempSync(join(tmpdir(), 'zooid-agents-'))
+})
+afterEach(() => rmSync(agentsDir, { recursive: true, force: true }))
+
+describe('makeSyncCursorStore', () => {
+  it('returns null before any save (cold start)', () => {
+    const store = makeSyncCursorStore(agentsDir)
+    expect(store.loadSince('docs')).toBeNull()
+  })
+
+  it('round-trips a since cursor per agent name', () => {
+    const store = makeSyncCursorStore(agentsDir)
+    store.saveSince('docs', 's42')
+    store.saveSince('triage', 's7')
+    expect(store.loadSince('docs')).toBe('s42')
+    expect(store.loadSince('triage')).toBe('s7')
+  })
+
+  it('persists across store instances (simulates daemon restart)', () => {
+    makeSyncCursorStore(agentsDir).saveSince('docs', 's99')
+    expect(makeSyncCursorStore(agentsDir).loadSince('docs')).toBe('s99')
+  })
+
+  it('writes sync-since beside sessions.json under <agentsDir>/<agentName>/', () => {
+    makeSyncCursorStore(agentsDir).saveSince('docs', 's1')
+    const path = join(agentsDir, 'docs', 'sync-since')
+    expect(existsSync(path)).toBe(true)
+    expect(readFileSync(path, 'utf8')).toBe('s1')
+  })
+})

--- a/packages/cli/src/daemon/sync-cursors.ts
+++ b/packages/cli/src/daemon/sync-cursors.ts
@@ -1,0 +1,31 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface SyncCursorStore {
+  loadSince(agentName: string): string | null
+  saveSince(agentName: string, since: string): void
+}
+
+/**
+ * File-backed `since` cursor store: `<agentsDir>/<agentName>/sync-since`, next
+ * to the `(threadId → sessionId)` `sessions.json` buildAcpRegistry writes. Same
+ * per-agent durable-state root, so an agent's restart-surviving state lives in
+ * one folder. Agent names are validated kebab-case keys (ZOD063 isValidAgentKey),
+ * so they're safe path segments — no hashing needed.
+ */
+export function makeSyncCursorStore(agentsDir: string): SyncCursorStore {
+  const fileFor = (agentName: string): string => join(agentsDir, agentName, 'sync-since')
+  return {
+    loadSince(agentName) {
+      try {
+        return readFileSync(fileFor(agentName), 'utf8').trim() || null
+      } catch {
+        return null
+      }
+    },
+    saveSince(agentName, since) {
+      mkdirSync(join(agentsDir, agentName), { recursive: true })
+      writeFileSync(fileFor(agentName), since, 'utf8')
+    },
+  }
+}

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { loadZooidConfig, mergeCliFlags } from './config.js'
+import { loadZooidConfig, mergeCliFlags, findMatrixTransport } from './config.js'
 import type { ZooidConfig } from './types.js'
 
 const HTTP_TRANSPORT = `
@@ -1392,5 +1392,65 @@ agents:
     expect(cfg.agents.docs.workdir).toBe('./agents/docs')
     expect(cfg.agents.docs.matrix?.transport).toBe('matrix')
     expect(cfg.agents.docs.matrix?.user_id).toBe('@docs-agent:localhost')
+  })
+})
+
+// --- ZOD063: workstation slug, mode, port xor advertise_url ---
+
+const slugBase = (extra: string) => `
+runtime: podman
+slug: laptop
+transports:
+  matrix:
+    homeserver: https://zoon.eco
+    as_token: as-tok
+    hs_token: hs-tok
+${extra}
+agents:
+  docs:
+    acp: { preset: opencode }
+    matrix: { rooms: ['#docs'] }
+`
+
+describe('ZOD063: transport mode', () => {
+  it("defaults mode to 'appservice'", () => {
+    const cfg = loadZooidConfig(slugBase('    port: 9099'))
+    expect(findMatrixTransport(cfg)!.transport.mode).toBe('appservice')
+  })
+  it('rejects an unknown mode', () => {
+    expect(() => loadZooidConfig(slugBase('    mode: peer\n    port: 9099')))
+      .toThrow(/mode.*appservice.*client/i)
+  })
+})
+
+describe('ZOD063: port xor advertise_url', () => {
+  it('errors when BOTH are set', () => {
+    expect(() =>
+      loadZooidConfig(slugBase('    port: 9099\n    advertise_url: http://10.0.1.5:9099')),
+    ).toThrow(/port.*advertise_url|advertise_url.*port/i)
+  })
+  it('defaults to port 9099 when NEITHER is set (co-located mode)', () => {
+    const m = findMatrixTransport(loadZooidConfig(slugBase('')))!.transport
+    expect(m.port).toBe(9099)
+    expect(m.advertise_url).toBeUndefined()
+  })
+  it('accepts advertise_url alone', () => {
+    const m = findMatrixTransport(
+      loadZooidConfig(slugBase('    advertise_url: http://10.0.1.5:9099')),
+    )!.transport
+    expect(m.advertise_url).toBe('http://10.0.1.5:9099')
+    expect(m.port).toBeUndefined()
+  })
+})
+
+describe('ZOD063: slug-derived identity', () => {
+  it('derives sender_localpart and an exclusive slug namespace from top-level slug', () => {
+    const m = findMatrixTransport(loadZooidConfig(slugBase('    port: 9099')))!.transport
+    expect(m.sender_localpart).toBe('laptop')
+    expect(m.user_namespace).toBe('@laptop\\..*:zoon.eco')
+  })
+  it('rejects an invalid slug', () => {
+    expect(() => loadZooidConfig(slugBase('    port: 9099').replace('slug: laptop', 'slug: Lap.Top')))
+      .toThrow(/slug/i)
   })
 })

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1395,11 +1395,11 @@ agents:
   })
 })
 
-// --- ZOD063: workstation slug, mode, port xor advertise_url ---
+// --- ZOD063: workstation, mode, port xor advertise_url ---
 
-const slugBase = (extra: string) => `
+const workstationBase = (extra: string) => `
 runtime: podman
-slug: laptop
+workstation: laptop
 transports:
   matrix:
     homeserver: https://zoon.eco
@@ -1414,11 +1414,11 @@ agents:
 
 describe('ZOD063: transport mode', () => {
   it("defaults mode to 'appservice'", () => {
-    const cfg = loadZooidConfig(slugBase('    port: 9099'))
+    const cfg = loadZooidConfig(workstationBase('    port: 9099'))
     expect(findMatrixTransport(cfg)!.transport.mode).toBe('appservice')
   })
   it('rejects an unknown mode', () => {
-    expect(() => loadZooidConfig(slugBase('    mode: peer\n    port: 9099')))
+    expect(() => loadZooidConfig(workstationBase('    mode: peer\n    port: 9099')))
       .toThrow(/mode.*appservice.*client/i)
   })
 })
@@ -1426,31 +1426,34 @@ describe('ZOD063: transport mode', () => {
 describe('ZOD063: port xor advertise_url', () => {
   it('errors when BOTH are set', () => {
     expect(() =>
-      loadZooidConfig(slugBase('    port: 9099\n    advertise_url: http://10.0.1.5:9099')),
+      loadZooidConfig(workstationBase('    port: 9099\n    advertise_url: http://10.0.1.5:9099')),
     ).toThrow(/port.*advertise_url|advertise_url.*port/i)
   })
   it('defaults to port 9099 when NEITHER is set (co-located mode)', () => {
-    const m = findMatrixTransport(loadZooidConfig(slugBase('')))!.transport
+    const m = findMatrixTransport(loadZooidConfig(workstationBase('')))!.transport
     expect(m.port).toBe(9099)
     expect(m.advertise_url).toBeUndefined()
   })
   it('accepts advertise_url alone', () => {
     const m = findMatrixTransport(
-      loadZooidConfig(slugBase('    advertise_url: http://10.0.1.5:9099')),
+      loadZooidConfig(workstationBase('    advertise_url: http://10.0.1.5:9099')),
     )!.transport
     expect(m.advertise_url).toBe('http://10.0.1.5:9099')
     expect(m.port).toBeUndefined()
   })
 })
 
-describe('ZOD063: slug-derived identity', () => {
-  it('derives sender_localpart and an exclusive slug namespace from top-level slug', () => {
-    const m = findMatrixTransport(loadZooidConfig(slugBase('    port: 9099')))!.transport
+describe('ZOD063: workstation-derived identity', () => {
+  it('derives sender_localpart and an exclusive workstation namespace from top-level workstation', () => {
+    const m = findMatrixTransport(loadZooidConfig(workstationBase('    port: 9099')))!.transport
     expect(m.sender_localpart).toBe('laptop')
     expect(m.user_namespace).toBe('@laptop\\..*:zoon.eco')
   })
-  it('rejects an invalid slug', () => {
-    expect(() => loadZooidConfig(slugBase('    port: 9099').replace('slug: laptop', 'slug: Lap.Top')))
-      .toThrow(/slug/i)
+  it('rejects an invalid workstation', () => {
+    expect(() =>
+      loadZooidConfig(
+        workstationBase('    port: 9099').replace('workstation: laptop', 'workstation: Lap.Top'),
+      ),
+    ).toThrow(/workstation/i)
   })
 })

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -326,7 +326,7 @@ function parseZooidContainer(raw: unknown): ZooidContainerConfig {
 function parseTransports(
   raw: unknown,
   processEnv: NodeJS.ProcessEnv,
-  slug?: string,
+  workstation?: string,
 ): Record<string, TransportConfig> {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error('transports: must be a mapping with at least one entry')
@@ -338,7 +338,7 @@ function parseTransports(
   }
   const out: Record<string, TransportConfig> = {}
   for (const name of names) {
-    out[name] = parseTransport(name, r[name], processEnv, slug)
+    out[name] = parseTransport(name, r[name], processEnv, workstation)
   }
   const matrixEntries = Object.entries(out).filter(
     (e): e is [string, MatrixTransportConfig] => e[1].type === 'matrix',
@@ -382,7 +382,7 @@ function parseTransport(
   name: string,
   raw: unknown,
   processEnv: NodeJS.ProcessEnv,
-  slug?: string,
+  workstation?: string,
 ): TransportConfig {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error(`transports.${name}: must be a mapping`)
@@ -411,7 +411,7 @@ function parseTransport(
       )
     }
 
-    // Slug-derived defaults: sender_localpart and user_namespace
+    // Workstation-derived defaults: sender_localpart and user_namespace
     let resolvedHost: string | undefined
     if (typeof r.homeserver === 'string') {
       try {
@@ -421,13 +421,13 @@ function parseTransport(
       }
     }
 
-    if (slug !== undefined) {
-      if (!SLUG_RE.test(slug)) {
-        throw new Error(`slug must match /^[a-z0-9-]+$/ (got ${JSON.stringify(slug)})`)
+    if (workstation !== undefined) {
+      if (!SLUG_RE.test(workstation)) {
+        throw new Error(`workstation must match /^[a-z0-9-]+$/ (got ${JSON.stringify(workstation)})`)
       }
-      if (r.sender_localpart === undefined) r.sender_localpart = slug
+      if (r.sender_localpart === undefined) r.sender_localpart = workstation
       if (r.user_namespace === undefined && resolvedHost) {
-        r.user_namespace = `@${slug}\\..*:${resolvedHost}`
+        r.user_namespace = `@${workstation}\\..*:${resolvedHost}`
       }
     } else {
       if (r.sender_localpart === undefined) r.sender_localpart = 'zooid'
@@ -459,7 +459,7 @@ function parseTransport(
       user_namespace: r.user_namespace as string,
       mode: mode as 'appservice' | 'client',
     }
-    if (slug !== undefined) out.slug = slug
+    if (workstation !== undefined) out.workstation = workstation
 
     if (r.port !== undefined) {
       if (!Number.isInteger(r.port)) {
@@ -840,18 +840,18 @@ export function loadZooidConfig(
   const runtime = parseRuntime(r.runtime)
   const processEnv = process.env
 
-  let slug: string | undefined
-  if (r.slug !== undefined) {
-    if (typeof r.slug !== 'string' || r.slug.length === 0) {
-      throw new Error('slug must be a non-empty string')
+  let workstation: string | undefined
+  if (r.workstation !== undefined) {
+    if (typeof r.workstation !== 'string' || r.workstation.length === 0) {
+      throw new Error('workstation must be a non-empty string')
     }
-    if (!SLUG_RE.test(r.slug)) {
-      throw new Error(`slug must match /^[a-z0-9-]+$/ (got ${JSON.stringify(r.slug)})`)
+    if (!SLUG_RE.test(r.workstation)) {
+      throw new Error(`workstation must match /^[a-z0-9-]+$/ (got ${JSON.stringify(r.workstation)})`)
     }
-    slug = r.slug
+    workstation = r.workstation
   }
 
-  const transports = parseTransports(r.transports, processEnv, slug)
+  const transports = parseTransports(r.transports, processEnv, workstation)
   const hooks = zooidHooks(r)
   const agents = parseAgents(r.agents, runtime, transports, hooks, processEnv, opts.configDir)
 
@@ -861,7 +861,7 @@ export function loadZooidConfig(
     agents,
     hooks,
   }
-  if (slug !== undefined) cfg.slug = slug
+  if (workstation !== undefined) cfg.workstation = workstation
   if (r.container !== undefined && r.container !== null) {
     if (runtime === 'local') {
       throw new Error(

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -19,6 +19,8 @@ import type {
   ZooidContainerConfig,
 } from './types.js'
 
+const SLUG_RE = /^[a-z0-9-]+$/
+
 export interface LoadZooidConfigOptions {
   /**
    * Directory containing zooid.yaml. Required when any agent uses a
@@ -324,6 +326,7 @@ function parseZooidContainer(raw: unknown): ZooidContainerConfig {
 function parseTransports(
   raw: unknown,
   processEnv: NodeJS.ProcessEnv,
+  slug?: string,
 ): Record<string, TransportConfig> {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error('transports: must be a mapping with at least one entry')
@@ -335,7 +338,7 @@ function parseTransports(
   }
   const out: Record<string, TransportConfig> = {}
   for (const name of names) {
-    out[name] = parseTransport(name, r[name], processEnv)
+    out[name] = parseTransport(name, r[name], processEnv, slug)
   }
   const matrixEntries = Object.entries(out).filter(
     (e): e is [string, MatrixTransportConfig] => e[1].type === 'matrix',
@@ -379,6 +382,7 @@ function parseTransport(
   name: string,
   raw: unknown,
   processEnv: NodeJS.ProcessEnv,
+  slug?: string,
 ): TransportConfig {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error(`transports.${name}: must be a mapping`)
@@ -392,19 +396,46 @@ function parseTransport(
     )
   }
   if (inferredType === 'matrix') {
-    if (r.sender_localpart === undefined) r.sender_localpart = 'zooid'
-    if (r.user_namespace === undefined && typeof r.homeserver === 'string') {
+    // Validate mode first so we can give a clear error.
+    const mode = r.mode ?? 'appservice'
+    if (mode !== 'appservice' && mode !== 'client') {
+      throw new Error(
+        `transports.${name}.mode must be "appservice" or "client" (got ${JSON.stringify(r.mode)})`,
+      )
+    }
+
+    // port xor advertise_url
+    if (r.port !== undefined && r.advertise_url !== undefined) {
+      throw new Error(
+        `transports.${name}: set 'port' or 'advertise_url', not both`,
+      )
+    }
+
+    // Slug-derived defaults: sender_localpart and user_namespace
+    let resolvedHost: string | undefined
+    if (typeof r.homeserver === 'string') {
       try {
-        const host = new URL(
-          interpolateString(r.homeserver as string, processEnv),
-        ).hostname
-        if (host) r.user_namespace = `@.*:${host}`
+        resolvedHost = new URL(interpolateString(r.homeserver as string, processEnv)).hostname
       } catch {
-        // Fall through: the required-fields loop will fire its "must be a
-        // non-empty string" error, which is the same message today's parser
-        // would emit for a bad homeserver URL.
+        // fall through — required-field check below fires the error
       }
     }
+
+    if (slug !== undefined) {
+      if (!SLUG_RE.test(slug)) {
+        throw new Error(`slug must match /^[a-z0-9-]+$/ (got ${JSON.stringify(slug)})`)
+      }
+      if (r.sender_localpart === undefined) r.sender_localpart = slug
+      if (r.user_namespace === undefined && resolvedHost) {
+        r.user_namespace = `@${slug}\\..*:${resolvedHost}`
+      }
+    } else {
+      if (r.sender_localpart === undefined) r.sender_localpart = 'zooid'
+      if (r.user_namespace === undefined && resolvedHost) {
+        r.user_namespace = `@.*:${resolvedHost}`
+      }
+    }
+
     if (r.as_token === undefined) r.as_token = '__INFER__'
     if (r.hs_token === undefined) r.hs_token = '__INFER__'
     const fields = [
@@ -426,7 +457,10 @@ function parseTransport(
       hs_token: interpolateString(r.hs_token as string, processEnv),
       sender_localpart: r.sender_localpart as string,
       user_namespace: r.user_namespace as string,
+      mode: mode as 'appservice' | 'client',
     }
+    if (slug !== undefined) out.slug = slug
+
     if (r.port !== undefined) {
       if (!Number.isInteger(r.port)) {
         throw new Error(
@@ -434,7 +468,16 @@ function parseTransport(
         )
       }
       out.port = r.port as number
+    } else if (r.advertise_url !== undefined) {
+      if (typeof r.advertise_url !== 'string' || r.advertise_url.length === 0) {
+        throw new Error(`transports.${name}.advertise_url must be a non-empty string`)
+      }
+      out.advertise_url = r.advertise_url as string
+    } else {
+      // Neither set — default to co-located port
+      out.port = 9099
     }
+
     if (r.space !== undefined) {
       if (typeof r.space !== 'string' || r.space.length === 0) {
         throw new Error(
@@ -796,7 +839,19 @@ export function loadZooidConfig(
 
   const runtime = parseRuntime(r.runtime)
   const processEnv = process.env
-  const transports = parseTransports(r.transports, processEnv)
+
+  let slug: string | undefined
+  if (r.slug !== undefined) {
+    if (typeof r.slug !== 'string' || r.slug.length === 0) {
+      throw new Error('slug must be a non-empty string')
+    }
+    if (!SLUG_RE.test(r.slug)) {
+      throw new Error(`slug must match /^[a-z0-9-]+$/ (got ${JSON.stringify(r.slug)})`)
+    }
+    slug = r.slug
+  }
+
+  const transports = parseTransports(r.transports, processEnv, slug)
   const hooks = zooidHooks(r)
   const agents = parseAgents(r.agents, runtime, transports, hooks, processEnv, opts.configDir)
 
@@ -806,6 +861,7 @@ export function loadZooidConfig(
     agents,
     hooks,
   }
+  if (slug !== undefined) cfg.slug = slug
   if (r.container !== undefined && r.container !== null) {
     if (runtime === 'local') {
       throw new Error(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -199,12 +199,12 @@ export interface MatrixTransportConfig {
   hs_token: string
   /**
    * Localpart of the AS sender user (the bridge bot).
-   * @default 'zooid', or the workstation slug when `slug` is set
+   * @default 'zooid', or the workstation name when `workstation` is set
    */
   sender_localpart: string
   /**
    * Regex covering all bot users, e.g. `@.*:example.com`.
-   * @default `@.*:<host>`, or slug-scoped `@slug\..*:<host>` when `slug` is set
+   * @default `@.*:<host>`, or workstation-scoped `@<workstation>\..*:<host>` when `workstation` is set
    */
   user_namespace: string
   /**
@@ -226,11 +226,11 @@ export interface MatrixTransportConfig {
    */
   mode?: 'appservice' | 'client'
   /**
-   * Workstation slug derived from the top-level `slug:` in zooid.yaml.
-   * Present only when a slug is declared; absent for the shared-namespace
-   * `zooid dev` profile.
+   * Workstation identity derived from the top-level `workstation:` in
+   * zooid.yaml. Present only when a workstation is declared; absent for the
+   * shared-namespace `zooid dev` profile.
    */
-  slug?: string
+  workstation?: string
   /**
    * Workforce space localpart. Resolves to alias `#<space>:<server>`.
    * @default 'dev'
@@ -260,12 +260,12 @@ export type TransportConfig = MatrixTransportConfig | HttpTransportConfig
 export interface ZooidConfig {
   runtime: 'local' | 'docker' | 'podman'
   /**
-   * Workstation identity slug. A short, lowercase, hyphen-separated name that
+   * Workstation identity. A short, lowercase, hyphen-separated name that
    * uniquely identifies this daemon instance (e.g. `laptop`, `ec2-prod`).
    * When set, the matrix transport derives `sender_localpart` and
    * `user_namespace` from it, enabling exclusive per-workstation AS namespaces.
    */
-  slug?: string
+  workstation?: string
   /** Workforce-wide container defaults. Image only — no workforce-level env. Rejected when runtime: local. */
   container?: ZooidContainerConfig
   /** Required. Map of operator-chosen names → transport config. At least one entry. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -181,9 +181,8 @@ export interface AgentConfig {
 
 /**
  * Matrix application-service transport. The CLI binds the AS HTTP listener
- * to `port` (defaults to 9000 — the most common Matrix AS convention; see
- * Synapse / mautrix / matrix-appservice-* projects). Must match the port in
- * the registration YAML's `url` (read by the homeserver, not by Zooid).
+ * to `port` (defaults to 9099 for co-located/community-box mode). Must match
+ * the port in the registration YAML's `url` (read by the homeserver, not by Zooid).
  */
 export interface MatrixTransportConfig {
   type: 'matrix'
@@ -200,22 +199,38 @@ export interface MatrixTransportConfig {
   hs_token: string
   /**
    * Localpart of the AS sender user (the bridge bot).
-   * @default 'zooid'
+   * @default 'zooid', or the workstation slug when `slug` is set
    */
   sender_localpart: string
   /**
    * Regex covering all bot users, e.g. `@.*:example.com`.
-   * @default `@.*:<host>` — host derived from `homeserver`
+   * @default `@.*:<host>`, or slug-scoped `@slug\..*:<host>` when `slug` is set
    */
   user_namespace: string
   /**
-   * AS HTTP listener port. Must match the registration YAML's `url` port —
-   * Zooid never reads the registration, so a mismatch silently sinks every
-   * transaction (the homeserver gets connection refused; you see no error
-   * in Zooid's logs).
-   * @default 9000
+   * AS HTTP listener port. Mutually exclusive with `advertise_url`.
+   * When set, the registration `url` is `http://host.docker.internal:<port>`.
+   * @default 9099 (co-located mode) when neither port nor advertise_url is set
    */
   port?: number
+  /**
+   * Explicit registration URL advertised to the homeserver. Mutually exclusive
+   * with `port`. Use for multi-workstation setups where the homeserver reaches
+   * the daemon via a stable external address.
+   */
+  advertise_url?: string
+  /**
+   * AS mode. `appservice` = push transport (homeserver calls the daemon).
+   * `client` = pull transport (daemon polls /_matrix/client/v3/sync).
+   * @default 'appservice'
+   */
+  mode?: 'appservice' | 'client'
+  /**
+   * Workstation slug derived from the top-level `slug:` in zooid.yaml.
+   * Present only when a slug is declared; absent for the shared-namespace
+   * `zooid dev` profile.
+   */
+  slug?: string
   /**
    * Workforce space localpart. Resolves to alias `#<space>:<server>`.
    * @default 'dev'
@@ -244,6 +259,13 @@ export type TransportConfig = MatrixTransportConfig | HttpTransportConfig
  */
 export interface ZooidConfig {
   runtime: 'local' | 'docker' | 'podman'
+  /**
+   * Workstation identity slug. A short, lowercase, hyphen-separated name that
+   * uniquely identifies this daemon instance (e.g. `laptop`, `ec2-prod`).
+   * When set, the matrix transport derives `sender_localpart` and
+   * `user_namespace` from it, enabling exclusive per-workstation AS namespaces.
+   */
+  slug?: string
   /** Workforce-wide container defaults. Image only — no workforce-level env. Rejected when runtime: local. */
   container?: ZooidContainerConfig
   /** Required. Map of operator-chosen names → transport config. At least one entry. */

--- a/packages/transport-matrix/src/bot-pool.test.ts
+++ b/packages/transport-matrix/src/bot-pool.test.ts
@@ -248,8 +248,14 @@ describe('BotPool.bootstrap workforce-space attachment', () => {
       ],
     )
     await pool.bootstrap({ spaceRoomId: '!space:zoon.local', asUserId: '@zooid:zoon.local' })
+    // Created BY the AS sender bot (room owner/admin), never by the agent —
+    // agents join as plain members, never room admins.
     expect(createRoom).toHaveBeenCalledWith(
-      expect.objectContaining({ roomAliasName: 'design', restrictedToSpaceId: '!space:zoon.local' }),
+      expect.objectContaining({
+        roomAliasName: 'design',
+        restrictedToSpaceId: '!space:zoon.local',
+        senderUserId: '@zooid:zoon.local',
+      }),
     )
   })
 

--- a/packages/transport-matrix/src/bot-pool.ts
+++ b/packages/transport-matrix/src/bot-pool.ts
@@ -82,7 +82,13 @@ export class BotPool {
               } else {
                 const colon = room.indexOf(':')
                 const aliasLocalpart = colon > 1 ? room.slice(1, colon) : room.slice(1)
-                const sender = opts.adminUserId ?? a.userId
+                // Workstation-created rooms are owned by the AS sender bot (PL
+                // 100, already seeded in the power override below). Agents join
+                // as plain members and must never be room admins. The human
+                // operator is invited + seeded at PL 100, but can't be the
+                // creator under a workstation-scoped namespace — the AS token
+                // can't impersonate a non-namespaced human.
+                const sender = opts.asUserId ?? opts.adminUserId ?? a.userId
                 const userPowerLevels = buildUserPowerLevels(
                   opts.asUserId,
                   opts.adminUserIds,

--- a/packages/transport-matrix/src/identity.test.ts
+++ b/packages/transport-matrix/src/identity.test.ts
@@ -1,29 +1,29 @@
 import { describe, it, expect } from 'vitest'
 import {
-  isValidSlug,
+  isValidWorkstation,
   isValidAgentKey,
   agentMxid,
   splitAgentLocalpart,
-  slugUserNamespace,
+  workstationUserNamespace,
 } from './identity.js'
 
-describe('slug / agent grammar', () => {
+describe('workstation / agent grammar', () => {
   it('accepts dot-free lowercase-alnum-hyphen', () => {
-    expect(isValidSlug('laptop')).toBe(true)
-    expect(isValidSlug('ec2-prod')).toBe(true)
+    expect(isValidWorkstation('laptop')).toBe(true)
+    expect(isValidWorkstation('ec2-prod')).toBe(true)
     expect(isValidAgentKey('docs')).toBe(true)
   })
-  it('rejects dots (the slug/agent separator) and bad chars', () => {
-    expect(isValidSlug('lap.top')).toBe(false) // dot is the boundary, never inside
-    expect(isValidSlug('Laptop')).toBe(false) // strict ASCII lowercase
-    expect(isValidSlug('lap_top')).toBe(false)
-    expect(isValidSlug('')).toBe(false)
+  it('rejects dots (the workstation/agent separator) and bad chars', () => {
+    expect(isValidWorkstation('lap.top')).toBe(false) // dot is the boundary, never inside
+    expect(isValidWorkstation('Laptop')).toBe(false) // strict ASCII lowercase
+    expect(isValidWorkstation('lap_top')).toBe(false)
+    expect(isValidWorkstation('')).toBe(false)
     expect(isValidAgentKey('a.b')).toBe(false)
   })
 })
 
 describe('agentMxid', () => {
-  it('builds @{slug}.{agent}:server', () => {
+  it('builds @{workstation}.{agent}:server', () => {
     expect(agentMxid('laptop', 'assistant', 'zoon.eco')).toBe('@laptop.assistant:zoon.eco')
   })
   it('throws on invalid parts', () => {
@@ -33,17 +33,20 @@ describe('agentMxid', () => {
 })
 
 describe('splitAgentLocalpart — split on FIRST dot', () => {
-  it('recovers (slug, agent)', () => {
-    expect(splitAgentLocalpart('laptop.assistant')).toEqual({ slug: 'laptop', agent: 'assistant' })
+  it('recovers (workstation, agent)', () => {
+    expect(splitAgentLocalpart('laptop.assistant')).toEqual({
+      workstation: 'laptop',
+      agent: 'assistant',
+    })
   })
   it('throws when there is no separator', () => {
     expect(() => splitAgentLocalpart('zooid')).toThrow()
   })
 })
 
-describe('slugUserNamespace', () => {
-  it('emits an escaped-dot exclusive regex for the slug', () => {
-    // The literal dot must be escaped so @{slug}.* does not also match @{slug}X*
-    expect(slugUserNamespace('laptop', 'zoon.eco')).toBe('@laptop\\..*:zoon.eco')
+describe('workstationUserNamespace', () => {
+  it('emits an escaped-dot exclusive regex for the workstation', () => {
+    // The literal dot must be escaped so @{workstation}.* does not also match @{workstation}X*
+    expect(workstationUserNamespace('laptop', 'zoon.eco')).toBe('@laptop\\..*:zoon.eco')
   })
 })

--- a/packages/transport-matrix/src/identity.test.ts
+++ b/packages/transport-matrix/src/identity.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isValidSlug,
+  isValidAgentKey,
+  agentMxid,
+  splitAgentLocalpart,
+  slugUserNamespace,
+} from './identity.js'
+
+describe('slug / agent grammar', () => {
+  it('accepts dot-free lowercase-alnum-hyphen', () => {
+    expect(isValidSlug('laptop')).toBe(true)
+    expect(isValidSlug('ec2-prod')).toBe(true)
+    expect(isValidAgentKey('docs')).toBe(true)
+  })
+  it('rejects dots (the slug/agent separator) and bad chars', () => {
+    expect(isValidSlug('lap.top')).toBe(false) // dot is the boundary, never inside
+    expect(isValidSlug('Laptop')).toBe(false) // strict ASCII lowercase
+    expect(isValidSlug('lap_top')).toBe(false)
+    expect(isValidSlug('')).toBe(false)
+    expect(isValidAgentKey('a.b')).toBe(false)
+  })
+})
+
+describe('agentMxid', () => {
+  it('builds @{slug}.{agent}:server', () => {
+    expect(agentMxid('laptop', 'assistant', 'zoon.eco')).toBe('@laptop.assistant:zoon.eco')
+  })
+  it('throws on invalid parts', () => {
+    expect(() => agentMxid('lap.top', 'assistant', 'zoon.eco')).toThrow()
+    expect(() => agentMxid('laptop', 'a.b', 'zoon.eco')).toThrow()
+  })
+})
+
+describe('splitAgentLocalpart — split on FIRST dot', () => {
+  it('recovers (slug, agent)', () => {
+    expect(splitAgentLocalpart('laptop.assistant')).toEqual({ slug: 'laptop', agent: 'assistant' })
+  })
+  it('throws when there is no separator', () => {
+    expect(() => splitAgentLocalpart('zooid')).toThrow()
+  })
+})
+
+describe('slugUserNamespace', () => {
+  it('emits an escaped-dot exclusive regex for the slug', () => {
+    // The literal dot must be escaped so @{slug}.* does not also match @{slug}X*
+    expect(slugUserNamespace('laptop', 'zoon.eco')).toBe('@laptop\\..*:zoon.eco')
+  })
+})

--- a/packages/transport-matrix/src/identity.ts
+++ b/packages/transport-matrix/src/identity.ts
@@ -1,22 +1,27 @@
+// A workstation id (and an agent key) must be "slug-shaped": kebab-case,
+// MXID/alias-safe. SLUG_RE names the *format*; the domain noun is workstation.
 export const SLUG_RE = /^[a-z0-9-]+$/
 export const AGENT_KEY_RE = /^[a-z0-9-]+$/
 
-export const isValidSlug = (s: string): boolean => SLUG_RE.test(s)
+export const isValidWorkstation = (s: string): boolean => SLUG_RE.test(s)
 export const isValidAgentKey = (s: string): boolean => AGENT_KEY_RE.test(s)
 
-export function agentMxid(slug: string, agent: string, serverName: string): string {
-  if (!isValidSlug(slug)) throw new Error(`invalid slug: ${JSON.stringify(slug)}`)
+export function agentMxid(workstation: string, agent: string, serverName: string): string {
+  if (!isValidWorkstation(workstation))
+    throw new Error(`invalid workstation: ${JSON.stringify(workstation)}`)
   if (!isValidAgentKey(agent)) throw new Error(`invalid agent key: ${JSON.stringify(agent)}`)
-  return `@${slug}.${agent}:${serverName}`
+  return `@${workstation}.${agent}:${serverName}`
 }
 
-export function splitAgentLocalpart(localpart: string): { slug: string; agent: string } {
-  const i = localpart.indexOf('.') // first dot is the boundary; slug/agent are dot-free
-  if (i <= 0 || i === localpart.length - 1) throw new Error(`not a slug.agent localpart: ${localpart}`)
-  return { slug: localpart.slice(0, i), agent: localpart.slice(i + 1) }
+export function splitAgentLocalpart(localpart: string): { workstation: string; agent: string } {
+  const i = localpart.indexOf('.') // first dot is the boundary; workstation/agent are dot-free
+  if (i <= 0 || i === localpart.length - 1)
+    throw new Error(`not a workstation.agent localpart: ${localpart}`)
+  return { workstation: localpart.slice(0, i), agent: localpart.slice(i + 1) }
 }
 
-export function slugUserNamespace(slug: string, serverName: string): string {
-  if (!isValidSlug(slug)) throw new Error(`invalid slug: ${JSON.stringify(slug)}`)
-  return `@${slug}\\..*:${serverName}` // escaped dot — exclusive to this slug's agents
+export function workstationUserNamespace(workstation: string, serverName: string): string {
+  if (!isValidWorkstation(workstation))
+    throw new Error(`invalid workstation: ${JSON.stringify(workstation)}`)
+  return `@${workstation}\\..*:${serverName}` // escaped dot — exclusive to this workstation's agents
 }

--- a/packages/transport-matrix/src/identity.ts
+++ b/packages/transport-matrix/src/identity.ts
@@ -1,0 +1,22 @@
+export const SLUG_RE = /^[a-z0-9-]+$/
+export const AGENT_KEY_RE = /^[a-z0-9-]+$/
+
+export const isValidSlug = (s: string): boolean => SLUG_RE.test(s)
+export const isValidAgentKey = (s: string): boolean => AGENT_KEY_RE.test(s)
+
+export function agentMxid(slug: string, agent: string, serverName: string): string {
+  if (!isValidSlug(slug)) throw new Error(`invalid slug: ${JSON.stringify(slug)}`)
+  if (!isValidAgentKey(agent)) throw new Error(`invalid agent key: ${JSON.stringify(agent)}`)
+  return `@${slug}.${agent}:${serverName}`
+}
+
+export function splitAgentLocalpart(localpart: string): { slug: string; agent: string } {
+  const i = localpart.indexOf('.') // first dot is the boundary; slug/agent are dot-free
+  if (i <= 0 || i === localpart.length - 1) throw new Error(`not a slug.agent localpart: ${localpart}`)
+  return { slug: localpart.slice(0, i), agent: localpart.slice(i + 1) }
+}
+
+export function slugUserNamespace(slug: string, serverName: string): string {
+  if (!isValidSlug(slug)) throw new Error(`invalid slug: ${JSON.stringify(slug)}`)
+  return `@${slug}\\..*:${serverName}` // escaped dot — exclusive to this slug's agents
+}

--- a/packages/transport-matrix/src/index.ts
+++ b/packages/transport-matrix/src/index.ts
@@ -5,11 +5,11 @@ export type { MatrixContextProviderOpts } from './context-provider.js'
 export { renderRegistration } from './registration.js'
 export type { MatrixTransportConfig } from './registration.js'
 export {
-  isValidSlug,
+  isValidWorkstation,
   isValidAgentKey,
   agentMxid,
   splitAgentLocalpart,
-  slugUserNamespace,
+  workstationUserNamespace,
   SLUG_RE,
   AGENT_KEY_RE,
 } from './identity.js'
@@ -20,6 +20,8 @@ export type { AgentBinding, RouteMatch } from './router.js'
 export { BotPool } from './bot-pool.js'
 export { createMatrixTransport } from './transport.js'
 export type { CreateMatrixTransportOptions, MediaClientLike } from './transport.js'
+export { SyncLoop } from './sync-loop.js'
+export type { SyncLoopOptions, SyncResponse, SyncClient } from './sync-loop.js'
 export { ensureDefaultChannel, ensureWorkforceSpace, serverNameFromMxid } from './space-provisioner.js'
 export type { EnsureDefaultChannelOpts, EnsureSpaceOpts } from './space-provisioner.js'
 export {

--- a/packages/transport-matrix/src/index.ts
+++ b/packages/transport-matrix/src/index.ts
@@ -4,6 +4,15 @@ export { MatrixContextProvider } from './context-provider.js'
 export type { MatrixContextProviderOpts } from './context-provider.js'
 export { renderRegistration } from './registration.js'
 export type { MatrixTransportConfig } from './registration.js'
+export {
+  isValidSlug,
+  isValidAgentKey,
+  agentMxid,
+  splitAgentLocalpart,
+  slugUserNamespace,
+  SLUG_RE,
+  AGENT_KEY_RE,
+} from './identity.js'
 export { extractMentions } from './mentions.js'
 export type { MaybeMessage } from './mentions.js'
 export { route, isMediaMsgtype, MEDIA_MSGTYPES } from './router.js'

--- a/packages/transport-matrix/src/matrix-client.test.ts
+++ b/packages/transport-matrix/src/matrix-client.test.ts
@@ -478,6 +478,29 @@ describe('MatrixClient.leaveRoom', () => {
   })
 })
 
+describe('MatrixClient.sync (impersonated)', () => {
+  it('GETs /sync with ?user_id=, as_token bearer, since + timeout', async () => {
+    const fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ next_batch: 's2', rooms: { join: {} } }), { status: 200 }),
+    )
+    const c = new MatrixClient({
+      homeserver: 'https://zoon.eco',
+      asToken: 'as-tok',
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    })
+    const out = await c.sync({ asUserId: '@laptop.docs:zoon.eco', since: 's1', timeoutMs: 30000 })
+
+    expect(out.next_batch).toBe('s2')
+    const url = new URL(fetch.mock.calls[0]![0] as string)
+    expect(url.pathname).toBe('/_matrix/client/v3/sync')
+    expect(url.searchParams.get('user_id')).toBe('@laptop.docs:zoon.eco')
+    expect(url.searchParams.get('since')).toBe('s1')
+    expect(url.searchParams.get('timeout')).toBe('30000')
+    const headers = (fetch.mock.calls[0]![1] as RequestInit).headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer as-tok')
+  })
+})
+
 describe('MatrixClient.createRoom restricted', () => {
   it('injects a restricted join rule referencing the space when restrictedToSpaceId is set', async () => {
     const fetch = fakeFetch(async ({ url, init }) => {

--- a/packages/transport-matrix/src/matrix-client.ts
+++ b/packages/transport-matrix/src/matrix-client.ts
@@ -420,6 +420,38 @@ export class MatrixClient {
     return (await r.json()) as { joined: Record<string, { display_name?: string }> }
   }
 
+  async sync(opts: {
+    asUserId: string
+    since?: string | null
+    timeoutMs?: number
+  }): Promise<{
+    next_batch: string
+    rooms: {
+      join: Record<string, {
+        timeline: { events: Record<string, unknown>[]; prev_batch?: string; limited?: boolean }
+      }>
+    }
+  }> {
+    const params = new URLSearchParams({
+      user_id: opts.asUserId,
+      timeout: String(opts.timeoutMs ?? 30_000),
+    })
+    if (opts.since) params.set('since', opts.since)
+    const url = `${this.homeserver}/_matrix/client/v3/sync?${params.toString()}`
+    const r = await this.fetch(url, {
+      headers: { Authorization: `Bearer ${this.asToken}` },
+    })
+    if (!r.ok) throw new Error(`sync(${opts.asUserId}) failed: ${r.status}`)
+    return r.json() as Promise<{
+      next_batch: string
+      rooms: {
+        join: Record<string, {
+          timeline: { events: Record<string, unknown>[]; prev_batch?: string; limited?: boolean }
+        }>
+      }
+    }>
+  }
+
   async fetchRoomName(roomId: string, asUserId: string): Promise<string | null> {
     const url =
       `${this.homeserver}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}` +

--- a/packages/transport-matrix/src/registration.test.ts
+++ b/packages/transport-matrix/src/registration.test.ts
@@ -41,7 +41,7 @@ describe('renderRegistration', () => {
   })
 })
 
-it('renders a slug-scoped EXCLUSIVE registration', () => {
+it('renders a workstation-scoped EXCLUSIVE registration', () => {
   const y = parse(
     renderRegistration({
       id: 'laptop',

--- a/packages/transport-matrix/src/registration.test.ts
+++ b/packages/transport-matrix/src/registration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { parse } from 'yaml'
 import { renderRegistration, type MatrixTransportConfig } from './registration.js'
 
 const baseConfig: MatrixTransportConfig = {
@@ -38,4 +39,23 @@ describe('renderRegistration', () => {
     const yaml = renderRegistration(baseConfig)
     expect(yaml).toContain('rate_limited: false')
   })
+})
+
+it('renders a slug-scoped EXCLUSIVE registration', () => {
+  const y = parse(
+    renderRegistration({
+      id: 'laptop',
+      url: 'http://10.0.1.5:9099',
+      homeserver: 'https://zoon.eco',
+      asToken: 'as-x',
+      hsToken: 'hs-x',
+      senderLocalpart: 'laptop',
+      userNamespace: '@laptop\\..*:zoon.eco',
+      exclusive: true,
+    }),
+  )
+  expect(y.sender_localpart).toBe('laptop')
+  expect(y.url).toBe('http://10.0.1.5:9099')
+  expect(y.namespaces.users[0]).toEqual({ exclusive: true, regex: '@laptop\\..*:zoon.eco' })
+  expect(y.namespaces.rooms).toEqual([]) // never fence by room id
 })

--- a/packages/transport-matrix/src/sync-loop.test.ts
+++ b/packages/transport-matrix/src/sync-loop.test.ts
@@ -51,4 +51,63 @@ describe('SyncLoop', () => {
     await loop.tick()
     expect((client.sync as ReturnType<typeof vi.fn>).mock.calls[0][0].since).toBe('s-persisted')
   })
+
+  it('tolerates an idle sync with no `rooms` key (real homeservers omit it)', async () => {
+    const store = new Map<string, string>()
+    const dispatched: string[] = []
+    // Real Tuwunel returns just { next_batch } on an idle incremental sync.
+    const client = fakeClient([{ next_batch: 's-idle' }])
+    const loop = new SyncLoop({
+      client: client as never,
+      asUserId: '@laptop.docs:zoon.eco',
+      loadSince: () => store.get('docs') ?? null,
+      saveSince: (s) => store.set('docs', s),
+      onEvent: (e) => dispatched.push(e.event_id as string),
+    })
+    await expect(loop.tick()).resolves.toBeUndefined()
+    expect(dispatched).toEqual([])
+    expect(store.get('docs')).toBe('s-idle') // cursor still advances
+  })
+
+  it('tolerates a joined room with no `timeline` (state/ephemeral-only update)', async () => {
+    const store = new Map<string, string>()
+    const dispatched: string[] = []
+    // A room can appear in rooms.join carrying only state — no timeline key.
+    const client = fakeClient([
+      { next_batch: 's-state', rooms: { join: { '!r': { state: { events: [] } } } } },
+    ])
+    const loop = new SyncLoop({
+      client: client as never,
+      asUserId: '@laptop.docs:zoon.eco',
+      loadSince: () => store.get('docs') ?? null,
+      saveSince: (s) => store.set('docs', s),
+      onEvent: (e) => dispatched.push(e.event_id as string),
+    })
+    await expect(loop.tick()).resolves.toBeUndefined()
+    expect(dispatched).toEqual([])
+    expect(store.get('docs')).toBe('s-state')
+  })
+
+  it('run() survives a throwing tick and keeps going (no daemon crash)', async () => {
+    let calls = 0
+    let loop!: SyncLoop
+    const client = {
+      sync: vi.fn(async () => {
+        calls++
+        if (calls === 1) throw new Error('transient /sync 502')
+        loop.stop() // recovered on the 2nd tick — end the loop deterministically
+        return { next_batch: 's-ok' }
+      }),
+    }
+    loop = new SyncLoop({
+      client: client as never,
+      asUserId: '@laptop.docs:zoon.eco',
+      loadSince: () => null,
+      saveSince: () => {},
+      onEvent: () => {},
+      retryDelayMs: 1,
+    })
+    await loop.run() // tick 1 throws → backoff → tick 2 recovers → stop → exits
+    expect(calls).toBe(2)
+  })
 })

--- a/packages/transport-matrix/src/sync-loop.test.ts
+++ b/packages/transport-matrix/src/sync-loop.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest'
+import { SyncLoop } from './sync-loop.js'
+
+const evt = (id: string, roomId: string) => ({
+  type: 'm.room.message',
+  event_id: id,
+  sender: '@me:zoon.eco',
+  room_id: roomId,
+  content: { msgtype: 'm.text', body: 'hi' },
+})
+
+function fakeClient(pages: unknown[]) {
+  let i = 0
+  return {
+    sync: vi.fn(async () => pages[Math.min(i++, pages.length - 1)]),
+  }
+}
+
+describe('SyncLoop', () => {
+  it('dispatches each timeline event once and persists next_batch', async () => {
+    const store = new Map<string, string>()
+    const dispatched: string[] = []
+    const client = fakeClient([
+      { next_batch: 's1', rooms: { join: { '!r': { timeline: { events: [evt('a', '!r')] } } } } },
+      { next_batch: 's2', rooms: { join: { '!r': { timeline: { events: [evt('b', '!r')] } } } } },
+      { next_batch: 's2', rooms: { join: {} } },
+    ])
+    const loop = new SyncLoop({
+      client: client as never,
+      asUserId: '@laptop.docs:zoon.eco',
+      loadSince: () => store.get('docs') ?? null,
+      saveSince: (s) => store.set('docs', s),
+      onEvent: (e) => dispatched.push(e.event_id as string),
+    })
+    await loop.tick()
+    await loop.tick()
+    expect(dispatched).toEqual(['a', 'b'])
+    expect(store.get('docs')).toBe('s2')
+  })
+
+  it('resumes from the persisted since (no reprocessing across restart)', async () => {
+    const store = new Map<string, string>([['docs', 's-persisted']])
+    const client = fakeClient([{ next_batch: 's3', rooms: { join: {} } }])
+    const loop = new SyncLoop({
+      client: client as never,
+      asUserId: '@laptop.docs:zoon.eco',
+      loadSince: () => store.get('docs') ?? null,
+      saveSince: (s) => store.set('docs', s),
+      onEvent: () => {},
+    })
+    await loop.tick()
+    expect((client.sync as ReturnType<typeof vi.fn>).mock.calls[0][0].since).toBe('s-persisted')
+  })
+})

--- a/packages/transport-matrix/src/sync-loop.ts
+++ b/packages/transport-matrix/src/sync-loop.ts
@@ -1,9 +1,13 @@
 export interface SyncResponse {
   next_batch: string
-  rooms: {
-    join: Record<string, {
-      timeline: {
-        events: Record<string, unknown>[]
+  // Real homeservers omit `rooms` (and `rooms.join`) entirely on an idle
+  // incremental sync — both are optional.
+  rooms?: {
+    join?: Record<string, {
+      // A joined room may carry only state/ephemeral/account_data on a given
+      // sync, with no `timeline` (or a timeline with no `events`).
+      timeline?: {
+        events?: Record<string, unknown>[]
         prev_batch?: string
         limited?: boolean
       }
@@ -22,6 +26,8 @@ export interface SyncLoopOptions {
   saveSince: (since: string) => void
   onEvent: (evt: Record<string, unknown>) => void | Promise<void>
   timeoutMs?: number
+  /** Backoff after a failed tick before retrying. Default 5000ms. */
+  retryDelayMs?: number
 }
 
 export class SyncLoop {
@@ -39,8 +45,8 @@ export class SyncLoop {
       since,
       timeoutMs: this.opts.timeoutMs ?? 30_000,
     })
-    for (const [roomId, roomState] of Object.entries(res.rooms.join)) {
-      for (const baseEvt of roomState.timeline.events) {
+    for (const [roomId, roomState] of Object.entries(res.rooms?.join ?? {})) {
+      for (const baseEvt of roomState.timeline?.events ?? []) {
         await this.opts.onEvent({ ...(baseEvt as Record<string, unknown>), room_id: roomId })
       }
     }
@@ -50,7 +56,15 @@ export class SyncLoop {
   async run(): Promise<void> {
     this.running = true
     while (this.running) {
-      await this.tick()
+      try {
+        await this.tick()
+      } catch (err) {
+        // A transient /sync failure (network blip, sleep/wake, 5xx) must not
+        // kill the loop — log and back off, then resume from the same `since`.
+        if (!this.running) break
+        console.warn(`[sync-loop] ${this.opts.asUserId} tick failed, retrying:`, err)
+        await new Promise((r) => setTimeout(r, this.opts.retryDelayMs ?? 5_000))
+      }
     }
   }
 

--- a/packages/transport-matrix/src/sync-loop.ts
+++ b/packages/transport-matrix/src/sync-loop.ts
@@ -1,0 +1,60 @@
+export interface SyncResponse {
+  next_batch: string
+  rooms: {
+    join: Record<string, {
+      timeline: {
+        events: Record<string, unknown>[]
+        prev_batch?: string
+        limited?: boolean
+      }
+    }>
+  }
+}
+
+export interface SyncClient {
+  sync(opts: { asUserId: string; since: string | null; timeoutMs: number }): Promise<SyncResponse>
+}
+
+export interface SyncLoopOptions {
+  client: SyncClient
+  asUserId: string
+  loadSince: () => string | null
+  saveSince: (since: string) => void
+  onEvent: (evt: Record<string, unknown>) => void | Promise<void>
+  timeoutMs?: number
+}
+
+export class SyncLoop {
+  private readonly opts: SyncLoopOptions
+  private running = false
+
+  constructor(opts: SyncLoopOptions) {
+    this.opts = opts
+  }
+
+  async tick(): Promise<void> {
+    const since = this.opts.loadSince()
+    const res = await this.opts.client.sync({
+      asUserId: this.opts.asUserId,
+      since,
+      timeoutMs: this.opts.timeoutMs ?? 30_000,
+    })
+    for (const [roomId, roomState] of Object.entries(res.rooms.join)) {
+      for (const baseEvt of roomState.timeline.events) {
+        await this.opts.onEvent({ ...(baseEvt as Record<string, unknown>), room_id: roomId })
+      }
+    }
+    this.opts.saveSince(res.next_batch)
+  }
+
+  async run(): Promise<void> {
+    this.running = true
+    while (this.running) {
+      await this.tick()
+    }
+  }
+
+  stop(): void {
+    this.running = false
+  }
+}

--- a/packages/transport-matrix/src/transport.ts
+++ b/packages/transport-matrix/src/transport.ts
@@ -19,6 +19,7 @@ import {
   INLINE_IMAGE_MIMES,
 } from './media-client.js'
 import { writeAttachment } from './attachments.js'
+import { SyncLoop } from './sync-loop.js'
 
 export interface MediaClientLike {
   download(input: {
@@ -56,6 +57,16 @@ export interface CreateMatrixTransportOptions {
    *  bindings this forms the set of "our bot users" whose ad-hoc invites are
    *  declined. */
   botUserId?: string
+  /**
+   * Transport ingestion mode.
+   * - `'appservice'` (default): Tuwunel pushes events to the HTTP transaction endpoint.
+   * - `'client'`: daemon polls via impersonated `/sync` per agent (pull mode).
+   */
+  mode?: 'appservice' | 'client'
+  /** Pull mode: load the persisted `since` cursor for an agent user ID. */
+  loadSince?: (agentUserId: string) => string | null
+  /** Pull mode: persist the `since` cursor after each sync poll. */
+  saveSince?: (agentUserId: string, since: string) => void
 }
 
 interface SessionContext {
@@ -223,7 +234,7 @@ function inboundThreadRoot(evt: MatrixEvent): string | undefined {
 }
 
 export function createMatrixTransport(opts: CreateMatrixTransportOptions) {
-  const { agents, approvals, client, bindings, hsToken, adminUserId, botUserId } = opts
+  const { agents, approvals, client, bindings, hsToken, adminUserId, botUserId, mode = 'appservice' } = opts
   const drainQuietMs = opts.drainQuietMs ?? DRAIN_QUIET_MS
   const drainMaxMs = opts.drainMaxMs ?? DRAIN_MAX_MS
   const mediaClient = opts.media
@@ -465,6 +476,249 @@ export function createMatrixTransport(opts: CreateMatrixTransportOptions) {
     })
   })
 
+  async function handleInboundEvent(evt: MatrixEvent): Promise<void> {
+    if (evt.event_id) {
+      if (seenEventIds.has(evt.event_id)) {
+        return
+      }
+      seenEventIds.add(evt.event_id)
+      if (seenEventIds.size > SEEN_EVENT_CAP) {
+        const first = seenEventIds.values().next().value
+        if (first !== undefined) seenEventIds.delete(first)
+      }
+    }
+    if (
+      evt.origin_server_ts !== undefined &&
+      evt.origin_server_ts < cutoffTs &&
+      evt.type === 'm.room.message'
+    ) {
+      console.log(
+        `[matrix] dropping stale message event ${evt.event_id} ` +
+          `(ts=${evt.origin_server_ts}, daemon started at ${cutoffTs + STARTUP_GRACE_MS})`,
+      )
+      return
+    }
+    if (evt.type === 'm.room.member' && evt.content?.membership === 'invite') {
+      const target = evt.state_key
+      const inviter = evt.sender
+      if (
+        target &&
+        evt.room_id &&
+        ourBotUserIds.has(target) &&
+        (!inviter || !ourBotUserIds.has(inviter))
+      ) {
+        console.log(
+          `[matrix] declining ad-hoc invite for ${target} in ${evt.room_id} ` +
+            `from ${inviter ?? 'unknown'}`,
+        )
+        await client
+          .leaveRoom(evt.room_id, target, { reason: DECLINE_REASON })
+          .catch((err) =>
+            console.warn(`[matrix] leaveRoom(${evt.room_id}, ${target}) failed:`, err),
+          )
+      }
+      return
+    }
+    if (evt.type === 'dev.zooid.session_reset') {
+      // Spec § /clear: room-scope reset is unsupported. Only thread-scoped
+      // resets carry a thread relation; drop bare room-level resets silently.
+      const relates = evt.content?.['m.relates_to'] as
+        | { rel_type?: string; event_id?: string }
+        | undefined
+      const threadRoot =
+        relates?.rel_type === 'm.thread' && relates.event_id ? relates.event_id : undefined
+      if (!threadRoot) {
+        console.log('[matrix] dropping dev.zooid.session_reset without thread relation')
+        return
+      }
+      console.log(`[matrix] inbound dev.zooid.session_reset in ${evt.room_id} thread=${threadRoot}`)
+      for (const a of bindings) {
+        agents.endSession(a.name, threadRoot)
+      }
+      // NB: keep threadStates intact. Per ZOD039 § /clear, only the agent's
+      // session memory is wiped — thread-routing state (participants /
+      // root-mentions) must survive so the next bare reply still routes to
+      // the most-recently-posting agent under the same sessionKey.
+      return
+    }
+    if (evt.type === 'dev.zooid.interrupt') {
+      const content = (evt.content ?? {}) as { session_id?: string; reason?: string }
+      // Thread-relation form (client-friendly): /interrupt in a thread sends
+      // an empty event with `m.relates_to: thread/<root>`. Cancel every
+      // session whose threadRoot matches.
+      const relates = evt.content?.['m.relates_to'] as
+        | { rel_type?: string; event_id?: string }
+        | undefined
+      const threadRoot =
+        relates?.rel_type === 'm.thread' && relates.event_id ? relates.event_id : undefined
+      if (threadRoot) {
+        const targets: Array<{ sessionId: string; agent: string }> = []
+        for (const [sessionId, ctx] of sessions) {
+          if (ctx.threadRoot === threadRoot) {
+            targets.push({ sessionId, agent: ctx.agent.name })
+          }
+        }
+        for (const t of targets) {
+          console.log(
+            `[matrix] interrupt session=${t.sessionId} agent=${t.agent} thread=${threadRoot}` +
+              (content.reason ? ` reason=${content.reason}` : ''),
+          )
+          await agents.cancelSession(t.agent, t.sessionId).catch((err) => {
+            console.error(`[matrix] cancelSession(${t.agent}, ${t.sessionId}) failed:`, err)
+          })
+        }
+        return
+      }
+      // Legacy form: explicit session_id in content.
+      if (!content.session_id) {
+        console.warn(`[matrix] dev.zooid.interrupt missing session_id (event_id=${evt.event_id})`)
+        return
+      }
+      const ctx = sessions.get(content.session_id)
+      if (!ctx) {
+        return
+      }
+      console.log(
+        `[matrix] interrupt session=${content.session_id} agent=${ctx.agent.name}` +
+          (content.reason ? ` reason=${content.reason}` : ''),
+      )
+      await agents.cancelSession(ctx.agent.name, content.session_id).catch((err) => {
+        console.error(`[matrix] cancelSession(${ctx.agent.name}, ${content.session_id}) failed:`, err)
+      })
+      return
+    }
+    if (evt.type === 'dev.zooid.approval_response') {
+      const content = (evt.content ?? {}) as {
+        approval_id?: string
+        session_id?: string
+        decision?: string
+        option_id?: string
+      }
+      if (!content.session_id || !content.approval_id || !content.decision) return
+      const decision = content.option_id
+        ? { decision: content.decision, optionId: content.option_id }
+        : { decision: content.decision }
+      const ok = approvals.resolve(
+        content.session_id,
+        content.approval_id,
+        decision as never,
+      )
+      if (!ok) console.warn(`[matrix] unknown approval ${content.approval_id}`)
+      return
+    }
+    logInbound(evt)
+
+    // Capture media events in the pending store; never route them to agents.
+    if (
+      evt.type === 'm.room.message' &&
+      isMediaMsgtype(evt.content?.msgtype) &&
+      evt.room_id &&
+      evt.event_id &&
+      evt.sender &&
+      evt.content?.url &&
+      !bindings.some((b) => b.userId === evt.sender)
+    ) {
+      pendingMedia.add(evt.room_id, inboundThreadRoot(evt), {
+        eventId: evt.event_id,
+        sender: evt.sender,
+        msgtype: evt.content.msgtype as string,
+        body: (evt.content.body as string | undefined) ?? '',
+        filename: evt.content.filename as string | undefined,
+        url: evt.content.url as string,
+        info: evt.content.info as PendingMediaItem['info'],
+      })
+      return
+    }
+
+    // Agent-promotion: top-level inbound event becomes the thread root.
+    // For in-thread messages the existing root is preserved.
+    const promotedRoot = inboundThreadRoot(evt) ?? evt.event_id
+    // Self-heal: if this is a thread reply but we have no in-memory state
+    // for the root (e.g. daemon was just restarted), reconstruct it by
+    // fetching the thread root + relations from the server.
+    const inboundRel = inboundThreadRoot(evt)
+    if (
+      evt.type === 'm.room.message' &&
+      inboundRel &&
+      !threadStates.has(inboundRel) &&
+      evt.room_id
+    ) {
+      try {
+        const rebuilt = await rebuildThreadState(client, evt.room_id, inboundRel, bindings)
+        threadStates.set(inboundRel, rebuilt)
+        console.log(
+          `[matrix] rebuilt threadState for ${inboundRel}: participants=${rebuilt.participants.join(',')} rootMentions=${rebuilt.rootMentions.join(',')}`,
+        )
+      } catch (err) {
+        console.warn(`[matrix] failed to rebuild threadState for ${inboundRel}:`, err)
+      }
+    }
+    const matches = route(evt, bindings, threadStates)
+    // Suppress the no-match warning for events sent by our own bots.
+    const senderIsBot = bindings.some((b) => b.userId === evt.sender)
+    if (evt.type === 'm.room.message' && matches.length === 0 && !senderIsBot) {
+      console.warn(
+        `[matrix] no agent matched message in ${evt.room_id} from ${evt.sender}` +
+          ` (bindings: ${bindings.map((b) => `${b.name}@${b.userId}[${b.trigger}]`).join(', ')})`,
+      )
+    }
+    // Seed thread state for any agent mentions in this event.
+    if (matches.length > 0 && promotedRoot) {
+      let st = threadStates.get(promotedRoot)
+      if (!st) {
+        st = { participants: [], rootMentions: [] }
+        threadStates.set(promotedRoot, st)
+      }
+      const msgMentions = new Set(extractMentions(evt as never))
+      for (const a of bindings) {
+        if (msgMentions.has(a.userId) && !st.rootMentions.includes(a.name)) {
+          st.rootMentions.push(a.name)
+        }
+      }
+    }
+    for (const a of matches) {
+      console.log(`[matrix] → ${a.name} (${a.userId})`)
+      void runTurn(a, evt)
+        .then(() => {
+          if (!promotedRoot) return
+          let st = threadStates.get(promotedRoot)
+          if (!st) {
+            st = { participants: [], rootMentions: [] }
+            threadStates.set(promotedRoot, st)
+          }
+          if (st.participants.at(-1) !== a.name) st.participants.push(a.name)
+        })
+        .catch((err) => {
+          console.error(`[matrix] runTurn failed for ${a.name}:`, err)
+          const c = classify(err)
+          const threadRoot = inboundThreadRoot(evt) ?? evt.event_id
+          if (!threadRoot || !evt.room_id) return
+          const body = toErrorBody(
+            {
+              kind: 'error',
+              agentId: a.name,
+              sessionId: null,
+              turnId: null,
+              code: c.code,
+              message: err instanceof Error ? err.message : String(err),
+              detail: err instanceof Error && err.stack ? err.stack.slice(0, 2000) : undefined,
+              transient: c.transient,
+              acp_error: c.acp_error,
+            },
+            threadRoot,
+          )
+          void client
+            .sendCustomEvent({
+              roomId: evt.room_id,
+              asUserId: a.userId,
+              eventType: 'dev.zooid.error',
+              content: body,
+            })
+            .catch((e) => console.warn(`[matrix:${a.name}] dev.zooid.error send failed:`, e))
+        })
+    }
+  }
+
   const app = new Hono()
 
   function authOk(authHeader: string | undefined): boolean {
@@ -481,246 +735,7 @@ export function createMatrixTransport(opts: CreateMatrixTransportOptions) {
     }
     const body = (await c.req.json().catch(() => ({}))) as { events?: MatrixEvent[] }
     for (const evt of body.events ?? []) {
-      if (evt.event_id) {
-        if (seenEventIds.has(evt.event_id)) {
-          continue
-        }
-        seenEventIds.add(evt.event_id)
-        if (seenEventIds.size > SEEN_EVENT_CAP) {
-          const first = seenEventIds.values().next().value
-          if (first !== undefined) seenEventIds.delete(first)
-        }
-      }
-      if (
-        evt.origin_server_ts !== undefined &&
-        evt.origin_server_ts < cutoffTs &&
-        evt.type === 'm.room.message'
-      ) {
-        console.log(
-          `[matrix] dropping stale message event ${evt.event_id} ` +
-            `(ts=${evt.origin_server_ts}, daemon started at ${cutoffTs + STARTUP_GRACE_MS})`,
-        )
-        continue
-      }
-      if (evt.type === 'm.room.member' && evt.content?.membership === 'invite') {
-        const target = evt.state_key
-        const inviter = evt.sender
-        if (
-          target &&
-          evt.room_id &&
-          ourBotUserIds.has(target) &&
-          (!inviter || !ourBotUserIds.has(inviter))
-        ) {
-          console.log(
-            `[matrix] declining ad-hoc invite for ${target} in ${evt.room_id} ` +
-              `from ${inviter ?? 'unknown'}`,
-          )
-          await client
-            .leaveRoom(evt.room_id, target, { reason: DECLINE_REASON })
-            .catch((err) =>
-              console.warn(`[matrix] leaveRoom(${evt.room_id}, ${target}) failed:`, err),
-            )
-        }
-        continue
-      }
-      if (evt.type === 'dev.zooid.session_reset') {
-        // Spec § /clear: room-scope reset is unsupported. Only thread-scoped
-        // resets carry a thread relation; drop bare room-level resets silently.
-        const relates = evt.content?.['m.relates_to'] as
-          | { rel_type?: string; event_id?: string }
-          | undefined
-        const threadRoot =
-          relates?.rel_type === 'm.thread' && relates.event_id ? relates.event_id : undefined
-        if (!threadRoot) {
-          console.log('[matrix] dropping dev.zooid.session_reset without thread relation')
-          continue
-        }
-        console.log(`[matrix] inbound dev.zooid.session_reset in ${evt.room_id} thread=${threadRoot}`)
-        for (const a of bindings) {
-          agents.endSession(a.name, threadRoot)
-        }
-        // NB: keep threadStates intact. Per ZOD039 § /clear, only the agent's
-        // session memory is wiped — thread-routing state (participants /
-        // root-mentions) must survive so the next bare reply still routes to
-        // the most-recently-posting agent under the same sessionKey.
-        continue
-      }
-      if (evt.type === 'dev.zooid.interrupt') {
-        const content = (evt.content ?? {}) as { session_id?: string; reason?: string }
-        // Thread-relation form (client-friendly): /interrupt in a thread sends
-        // an empty event with `m.relates_to: thread/<root>`. Cancel every
-        // session whose threadRoot matches.
-        const relates = evt.content?.['m.relates_to'] as
-          | { rel_type?: string; event_id?: string }
-          | undefined
-        const threadRoot =
-          relates?.rel_type === 'm.thread' && relates.event_id ? relates.event_id : undefined
-        if (threadRoot) {
-          const targets: Array<{ sessionId: string; agent: string }> = []
-          for (const [sessionId, ctx] of sessions) {
-            if (ctx.threadRoot === threadRoot) {
-              targets.push({ sessionId, agent: ctx.agent.name })
-            }
-          }
-          for (const t of targets) {
-            console.log(
-              `[matrix] interrupt session=${t.sessionId} agent=${t.agent} thread=${threadRoot}` +
-                (content.reason ? ` reason=${content.reason}` : ''),
-            )
-            await agents.cancelSession(t.agent, t.sessionId).catch((err) => {
-              console.error(`[matrix] cancelSession(${t.agent}, ${t.sessionId}) failed:`, err)
-            })
-          }
-          continue
-        }
-        // Legacy form: explicit session_id in content.
-        if (!content.session_id) {
-          console.warn(`[matrix] dev.zooid.interrupt missing session_id (event_id=${evt.event_id})`)
-          continue
-        }
-        const ctx = sessions.get(content.session_id)
-        if (!ctx) {
-          continue
-        }
-        console.log(
-          `[matrix] interrupt session=${content.session_id} agent=${ctx.agent.name}` +
-            (content.reason ? ` reason=${content.reason}` : ''),
-        )
-        await agents.cancelSession(ctx.agent.name, content.session_id).catch((err) => {
-          console.error(`[matrix] cancelSession(${ctx.agent.name}, ${content.session_id}) failed:`, err)
-        })
-        continue
-      }
-      if (evt.type === 'dev.zooid.approval_response') {
-        const content = (evt.content ?? {}) as {
-          approval_id?: string
-          session_id?: string
-          decision?: string
-          option_id?: string
-        }
-        if (!content.session_id || !content.approval_id || !content.decision) continue
-        const decision = content.option_id
-          ? { decision: content.decision, optionId: content.option_id }
-          : { decision: content.decision }
-        const ok = approvals.resolve(
-          content.session_id,
-          content.approval_id,
-          decision as never,
-        )
-        if (!ok) console.warn(`[matrix] unknown approval ${content.approval_id}`)
-        continue
-      }
-      logInbound(evt)
-
-      // Capture media events in the pending store; never route them to agents.
-      if (
-        evt.type === 'm.room.message' &&
-        isMediaMsgtype(evt.content?.msgtype) &&
-        evt.room_id &&
-        evt.event_id &&
-        evt.sender &&
-        evt.content?.url &&
-        !bindings.some((b) => b.userId === evt.sender)
-      ) {
-        pendingMedia.add(evt.room_id, inboundThreadRoot(evt), {
-          eventId: evt.event_id,
-          sender: evt.sender,
-          msgtype: evt.content.msgtype as string,
-          body: (evt.content.body as string | undefined) ?? '',
-          filename: evt.content.filename as string | undefined,
-          url: evt.content.url as string,
-          info: evt.content.info as PendingMediaItem['info'],
-        })
-        continue
-      }
-
-      // Agent-promotion: top-level inbound event becomes the thread root.
-      // For in-thread messages the existing root is preserved.
-      const promotedRoot = inboundThreadRoot(evt) ?? evt.event_id
-      // Self-heal: if this is a thread reply but we have no in-memory state
-      // for the root (e.g. daemon was just restarted), reconstruct it by
-      // fetching the thread root + relations from the server.
-      const inboundRel = inboundThreadRoot(evt)
-      if (
-        evt.type === 'm.room.message' &&
-        inboundRel &&
-        !threadStates.has(inboundRel) &&
-        evt.room_id
-      ) {
-        try {
-          const rebuilt = await rebuildThreadState(client, evt.room_id, inboundRel, bindings)
-          threadStates.set(inboundRel, rebuilt)
-          console.log(
-            `[matrix] rebuilt threadState for ${inboundRel}: participants=${rebuilt.participants.join(',')} rootMentions=${rebuilt.rootMentions.join(',')}`,
-          )
-        } catch (err) {
-          console.warn(`[matrix] failed to rebuild threadState for ${inboundRel}:`, err)
-        }
-      }
-      const matches = route(evt, bindings, threadStates)
-      // Suppress the no-match warning for events sent by our own bots.
-      const senderIsBot = bindings.some((b) => b.userId === evt.sender)
-      if (evt.type === 'm.room.message' && matches.length === 0 && !senderIsBot) {
-        console.warn(
-          `[matrix] no agent matched message in ${evt.room_id} from ${evt.sender}` +
-            ` (bindings: ${bindings.map((b) => `${b.name}@${b.userId}[${b.trigger}]`).join(', ')})`,
-        )
-      }
-      // Seed thread state for any agent mentions in this event.
-      if (matches.length > 0 && promotedRoot) {
-        let st = threadStates.get(promotedRoot)
-        if (!st) {
-          st = { participants: [], rootMentions: [] }
-          threadStates.set(promotedRoot, st)
-        }
-        const msgMentions = new Set(extractMentions(evt as never))
-        for (const a of bindings) {
-          if (msgMentions.has(a.userId) && !st.rootMentions.includes(a.name)) {
-            st.rootMentions.push(a.name)
-          }
-        }
-      }
-      for (const a of matches) {
-        console.log(`[matrix] → ${a.name} (${a.userId})`)
-        void runTurn(a, evt)
-          .then(() => {
-            if (!promotedRoot) return
-            let st = threadStates.get(promotedRoot)
-            if (!st) {
-              st = { participants: [], rootMentions: [] }
-              threadStates.set(promotedRoot, st)
-            }
-            if (st.participants.at(-1) !== a.name) st.participants.push(a.name)
-          })
-          .catch((err) => {
-            console.error(`[matrix] runTurn failed for ${a.name}:`, err)
-            const c = classify(err)
-            const threadRoot = inboundThreadRoot(evt) ?? evt.event_id
-            if (!threadRoot || !evt.room_id) return
-            const body = toErrorBody(
-              {
-                kind: 'error',
-                agentId: a.name,
-                sessionId: null,
-                turnId: null,
-                code: c.code,
-                message: err instanceof Error ? err.message : String(err),
-                detail: err instanceof Error && err.stack ? err.stack.slice(0, 2000) : undefined,
-                transient: c.transient,
-                acp_error: c.acp_error,
-              },
-              threadRoot,
-            )
-            void client
-              .sendCustomEvent({
-                roomId: evt.room_id,
-                asUserId: a.userId,
-                eventType: 'dev.zooid.error',
-                content: body,
-              })
-              .catch((e) => console.warn(`[matrix:${a.name}] dev.zooid.error send failed:`, e))
-          })
-      }
+      await handleInboundEvent(evt)
     }
     return c.json({})
   })
@@ -864,8 +879,23 @@ export function createMatrixTransport(opts: CreateMatrixTransportOptions) {
     }
   }
 
+  const syncLoops: SyncLoop[] | undefined =
+    mode === 'client'
+      ? bindings.map(
+          (b) =>
+            new SyncLoop({
+              client: client as never,
+              asUserId: b.userId,
+              loadSince: () => opts.loadSince?.(b.userId) ?? null,
+              saveSince: (since) => opts.saveSince?.(b.userId, since),
+              onEvent: (evt) => handleInboundEvent(evt as MatrixEvent),
+            }),
+        )
+      : undefined
+
   return {
     app,
+    syncLoops,
     bootstrap: async (
       bootstrapOpts: {
         spaceRoomId?: string

--- a/packages/transport-matrix/src/transport.ts
+++ b/packages/transport-matrix/src/transport.ts
@@ -259,9 +259,13 @@ export function createMatrixTransport(opts: CreateMatrixTransportOptions) {
   const sendQueue = new Map<string, Promise<void>>()
   // Thread participation index: keyed by thread root event_id.
   const threadStates = new Map<string, ThreadState>()
-  // Drop events older than this — Tuwunel may replay a backlog after the
-  // daemon was offline, and we don't want yesterday's "@docs hi" to fire now.
-  const cutoffTs = Date.now() - STARTUP_GRACE_MS
+  // Drop events older than this — in push (appservice) mode Tuwunel may replay
+  // a backlog after the daemon was offline, and we don't want yesterday's
+  // "@docs hi" to fire now. In pull (client) mode the persisted `since` cursor
+  // is the authoritative replay boundary (process everything after it — that's
+  // exactly the offline-resume feature), so the timestamp guard must NOT apply:
+  // the missed-while-offline mention is older than startup by design.
+  const cutoffTs = mode === 'client' ? Number.NEGATIVE_INFINITY : Date.now() - STARTUP_GRACE_MS
   // Idempotency: appservice transactions are retried on 4xx/5xx/timeout, and
   // the same event_id can arrive twice. Skip ones we've already taken.
   const seenEventIds = new Set<string>()

--- a/packages/transport-matrix/tests/pull-transport.integration.test.ts
+++ b/packages/transport-matrix/tests/pull-transport.integration.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { createMatrixTransport } from '../src/transport.js'
+
+function fakeRegistry() {
+  const reg = {
+    hasAgent: vi.fn(() => true),
+    ensureSession: vi.fn(
+      async (_name: string, threadId: string, _roomId: string) => `sess-${threadId}`,
+    ),
+    endSession: vi.fn(),
+    cancelSession: vi.fn(async () => {}),
+    prompt: vi.fn(async () => ({ stopReason: 'end_turn' as const })),
+    stopAll: vi.fn(async () => {}),
+    getApprovalTimeoutMs: vi.fn(() => 0),
+    onEvent: vi.fn() as unknown as (n: string, e: unknown) => void,
+    onApprovalRequest: vi.fn(async () => ({ decision: 'cancel' as const })),
+  }
+  return reg
+}
+
+function fakeApprovals() {
+  const e = new EventEmitter()
+  return Object.assign(e, {
+    register: vi.fn(),
+    resolve: vi.fn(() => true),
+    cancelSession: vi.fn(),
+    listPending: vi.fn(() => []),
+  })
+}
+
+const baseAgents = [
+  {
+    name: 'architect',
+    userId: '@architect:example.com',
+    rooms: [{ alias: '!r:example.com' }],
+    trigger: 'mention' as const,
+  },
+]
+
+const mentionEvt = {
+  type: 'm.room.message',
+  event_id: '$mention-1',
+  sender: '@alice:example.com',
+  origin_server_ts: Date.now(),
+  content: {
+    msgtype: 'm.text',
+    body: '@architect hi',
+    'm.mentions': { user_ids: ['@architect:example.com'] },
+  },
+}
+
+function makePullTransport(
+  pages: unknown[],
+  store: Map<string, string>,
+) {
+  let i = 0
+  const fakeClient = {
+    registerBot: vi.fn(async () => undefined),
+    joinRoom: vi.fn(async () => undefined),
+    leaveRoom: vi.fn(async () => undefined),
+    sendMessage: vi.fn(async () => ({ event_id: '$x' })),
+    sendCustomEvent: vi.fn(async () => ({ event_id: '$x' })),
+    setTyping: vi.fn(async () => {}),
+    setPresence: vi.fn(async () => {}),
+    fetchEvent: vi.fn(async () => null),
+    fetchThreadRelations: vi.fn(async () => ({ chunk: [] })),
+    sync: vi.fn(async () => pages[Math.min(i++, pages.length - 1)]),
+  }
+  const agents = fakeRegistry()
+  const approvals = fakeApprovals()
+  const transport = createMatrixTransport({
+    agents: agents as never,
+    approvals: approvals as never,
+    client: fakeClient as never,
+    bindings: baseAgents,
+    hsToken: 'hs-secret',
+    drainQuietMs: 0,
+    mode: 'client',
+    loadSince: (userId) => store.get(userId) ?? null,
+    saveSince: (userId, since) => store.set(userId, since),
+  })
+  return { transport, agents, fakeClient }
+}
+
+async function settleTurn(): Promise<void> {
+  for (let i = 0; i < 8; i++) await new Promise((r) => setImmediate(r))
+}
+
+describe('pull transport (mode: client)', () => {
+  it('dispatches a synced mention into runTurn exactly once and persists since', async () => {
+    const store = new Map<string, string>()
+    const pages = [
+      {
+        next_batch: 's1',
+        rooms: { join: { '!r:example.com': { timeline: { events: [mentionEvt] } } } },
+      },
+      { next_batch: 's1', rooms: { join: {} } },
+    ]
+
+    const { transport, agents } = makePullTransport(pages, store)
+    const loops = transport.syncLoops
+    expect(loops).toBeDefined()
+    expect(loops!.length).toBe(1)
+
+    await loops![0].tick()
+    await settleTurn()
+
+    expect(agents.prompt).toHaveBeenCalledOnce()
+    expect(agents.ensureSession).toHaveBeenCalledWith('architect', '$mention-1', '!r:example.com')
+    expect(store.get('@architect:example.com')).toBe('s1')
+  })
+
+  it('resumes from persisted since — fresh transport passes since on next tick', async () => {
+    const store = new Map<string, string>([['@architect:example.com', 's-persisted']])
+    const pages = [{ next_batch: 's2', rooms: { join: {} } }]
+
+    const { transport, fakeClient } = makePullTransport(pages, store)
+    await transport.syncLoops![0].tick()
+
+    expect(fakeClient.sync).toHaveBeenCalledWith(
+      expect.objectContaining({ since: 's-persisted', asUserId: '@architect:example.com' }),
+    )
+    expect(store.get('@architect:example.com')).toBe('s2')
+  })
+
+  it('does not reprocess a mention when a fresh transport starts from the persisted since', async () => {
+    const store = new Map<string, string>()
+
+    // First run: process the mention
+    const pages1 = [
+      {
+        next_batch: 's1',
+        rooms: { join: { '!r:example.com': { timeline: { events: [mentionEvt] } } } },
+      },
+    ]
+    const { transport: t1, agents: a1 } = makePullTransport(pages1, store)
+    await t1.syncLoops![0].tick()
+    await settleTurn()
+    expect(a1.prompt).toHaveBeenCalledOnce()
+    expect(store.get('@architect:example.com')).toBe('s1')
+
+    // Second run: idle page only — mention is NOT replayed because since='s1'
+    const pages2 = [{ next_batch: 's1', rooms: { join: {} } }]
+    const { transport: t2, agents: a2, fakeClient } = makePullTransport(pages2, store)
+    await t2.syncLoops![0].tick()
+    await settleTurn()
+
+    expect(fakeClient.sync).toHaveBeenCalledWith(
+      expect.objectContaining({ since: 's1' }),
+    )
+    expect(a2.prompt).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Brings the full multi-workstation / pull-transport arc to `main`. Three epics, linear history on this branch (none previously in `main`):

## ZOD063 — workstation identity & registration (`c010a50`)
Config + registration generation for a slugged **workstation**: `@{workstation}.{agent}:server` MXID grammar, `transports.matrix.mode`, `port` xor `advertise_url`, workstation-derived `sender_localpart` + exclusive `@{workstation}\..*` namespace.

## ZOD064 — pull transport (`338687f`)
`mode: 'client'` in `createMatrixTransport`: `MatrixClient.sync()`, a `SyncLoop` that polls `GET /sync?user_id=` per agent via the AS token, persists each agent's `since`, and dispatches into the same turn path as push.

## ZOD066 — daemon pull-mode wiring (`9618286`)
Wires the above into `zooid start` so it runs against a **remote** Tuwunel: reads `mode`, builds a file-backed per-agent `since` cursor (`<agentsDir>/<agentName>/sync-since`), skips the inbound HTTP listener in client mode (`port=0`), and `run()`/`stop()`s the sync loops.

**Live remote-Tuwunel smoke passed** (local daemon → agent turn over `/sync` against `community.zoon.eco`, plus offline-resume). The smoke caught three `SyncLoop` robustness bugs, now fixed + regression-tested:
- `tick()` crashed on an idle sync with no `rooms` / a room with no `timeline`
- `run()` crashed the daemon on any transient `/sync` error (now retries with backoff)
- the `transport.ts` stale-timestamp guard dropped offline-resume mentions in client mode (the persisted `since` is the authoritative boundary there)

Also renames the `slug` config key/concept to **`workstation`** throughout (key, types, identity helpers); only `SLUG_RE` (the kebab format regex) keeps the name.

## Tests
- transport-matrix 217 · core 187 · cli 163 — all green; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)