### PR TITLE
chore(images): bump pinned agent CLI versions

### DIFF
--- a/packages/runtime-docker/docker/agent-claude-code/Dockerfile
+++ b/packages/runtime-docker/docker/agent-claude-code/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/zooid-ai/agent-base:latest
 
 # ZOD074: the ARG default is the pin. docker/versions.json maps this ARG to its
 # npm package; image-versions.manifest.test.ts fails if the two disagree.
-ARG CLAUDE_AGENT_ACP_VERSION=0.74.0
+ARG CLAUDE_AGENT_ACP_VERSION=0.75.1
 RUN npm install -g @agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}
 
 # No CMD — DockerAcpRuntime sets the entrypoint to the resolved ACP shim

--- a/packages/runtime-docker/docker/agent-opencode/Dockerfile
+++ b/packages/runtime-docker/docker/agent-opencode/Dockerfile
@@ -2,5 +2,5 @@ FROM ghcr.io/zooid-ai/agent-base:latest
 
 # ZOD074: the ARG default is the pin. docker/versions.json maps this ARG to its
 # npm package; image-versions.manifest.test.ts fails if the two disagree.
-ARG OPENCODE_VERSION=1.18.27
+ARG OPENCODE_VERSION=1.18.29
 RUN npm install -g opencode-ai@${OPENCODE_VERSION}

--- a/packages/runtime-docker/docker/agent-pi/Dockerfile
+++ b/packages/runtime-docker/docker/agent-pi/Dockerfile
@@ -8,7 +8,7 @@ FROM ghcr.io/zooid-ai/agent-base:latest
 # unpinned and therefore freeze at whatever was current when someone last ran
 # the publish workflow by hand. [[ZOD074]] hoists all four into
 # docker/versions.json and automates the refresh.
-ARG PI_VERSION=0.85.0
+ARG PI_VERSION=0.85.1
 ARG PI_ACP_VERSION=0.0.33
 RUN npm install -g \
       @earendil-works/pi-coding-agent@${PI_VERSION} \


### PR DESCRIPTION
Pinned CLI versions in `packages/runtime-docker/docker/*/Dockerfile` are behind
the npm `latest` dist-tag. Merging republishes the affected `:latest` images.

| Image | Package | From | To |
|---|---|---|---|
| `agent-claude-code` | `@agentclientprotocol/claude-agent-acp` | 0.74.0 | 0.75.1 |
| `agent-opencode` | `opencode-ai` | 1.18.27 | 1.18.29 |
| `agent-pi` | `@earendil-works/pi-coding-agent` | 0.85.0 | 0.85.1 |

## Why this PR is manual

`agent-image-versions.yml` (ZOD074) produced this commit and pushed the branch on
2026-09-07, then failed to open the PR:

```
##[error]GitHub Actions is not permitted to create or approve pull requests.
```

That's an org/repo policy on the `github-actions[bot]` identity, not a workflow
bug — so the branch has been sitting here since with the work done and no PR.
Verified still current: `pnpm agent-images:check` on today's `main` reports the
same three bumps.

The fix is tracked as `[ZOD081]` daemon triggers, where a scheduled trigger wakes
an agent that opens the PR under a real account rather than as Actions. Until
then this workflow will keep stranding branches each Monday, so either flip
**Settings → Actions → General → "Allow GitHub Actions to create and approve pull
requests"** (note an org-level setting overrides the repo one) or expect to open
these by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoyoXbTFxGU1BjSodFqAxX